### PR TITLE
Make the auto navigation generation configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,13 @@ Altogether, your markup should look like this:
 </div>
 ```
 
+If you wish to use headings other than `<h2>` and `<h3>` in the navigation generation, you can customise the selector that's used. For example, to select only headings which have the class `nav-heading`, use the following:
+
+```diff
++ <div class="o-layout" data-o-component="o-layout" data-o-layout-nav-heading-selector=".nav-heading">
+- <div class="o-layout" data-o-component="o-layout">
+```
+
 #### Asides
 
 `o-layout` will make content asides literal asides to the content. As long as the aside is an aside element and placed _after_ the content it is an aside to, that element will line up correctly:
@@ -204,6 +211,13 @@ If you would like to define your own navigation, you will need to initialise `o-
 ```js
 const oLayout = require('o-layout');
 oLayout.init(null, { constructNav: false });
+```
+
+If you would like to specify a custom selector for the navigation generation, you can do so like this:
+
+```js
+const oLayout = require('o-layout');
+oLayout.init(null, { navHeadingSelector: '.nav-heading' });
 ```
 
 ---

--- a/src/js/layout.js
+++ b/src/js/layout.js
@@ -14,7 +14,7 @@ class Layout {
 			navHeadingSelector: 'h2, h3'
 		}, options || Layout.getDataAttributes(layoutEl));
 
-		this.headings = [...document.querySelectorAll(this.options.navHeadingSelector)]
+		this.headings = [...this.layoutEl.querySelectorAll(this.options.navHeadingSelector)]
 			.filter(heading => heading.getAttribute('id'));
 
 		if (this.options.constructNav) {

--- a/src/js/layout.js
+++ b/src/js/layout.js
@@ -10,10 +10,11 @@ class Layout {
 		//Default options
 		this.options = Object.assign({}, {
 			baseClass: 'o-layout',
-			constructNav: true
+			constructNav: true,
+			navHeadingSelector: 'h2, h3'
 		}, options || Layout.getDataAttributes(layoutEl));
 
-		this.headings = [...document.querySelectorAll('h2, h3')]
+		this.headings = [...document.querySelectorAll(this.options.navHeadingSelector)]
 			.filter(heading => heading.getAttribute('id'));
 
 		if (this.options.constructNav) {

--- a/test/layout.spec.js
+++ b/test/layout.spec.js
@@ -51,7 +51,8 @@ describe('Layout', () => {
 			assert.notStrictEqual(layout.options, options);
 			assert.deepEqual(layout.options, {
 				constructNav: true,
-				baseClass: 'o-layout'
+				baseClass: 'o-layout',
+				navHeadingSelector: 'h2, h3'
 			});
 		});
 
@@ -60,7 +61,8 @@ describe('Layout', () => {
 		});
 
 		it('does not construct navigation by default', () => {
-			layout = new Layout(null, {constructNav: false});
+			layoutElement = document.querySelector('[data-o-component=o-layout]');
+			layout = new Layout(layoutElement, {constructNav: false});
 			assert.calledOnce(stubs.constructNavFromDOM);
 		});
 


### PR DESCRIPTION
You can now configure the heading selector for the navigation
auto-generation. You can do so using a `navHeadingSelector`
configuration or a `data-o-layout-nav-heading-selector` data attribute
in the markup.

This resolves #5