### PR TITLE
correct highlighting behaviour

### DIFF
--- a/src/js/layout.js
+++ b/src/js/layout.js
@@ -53,6 +53,7 @@ class Layout {
 		let currentLocation;
 		let navAnchors = navigation.querySelectorAll('A');
 
+		//on page load, highlight the nav item that corresponds to the url
 		navAnchors.forEach((anchor, index) => {
 			if (location.hash === '' && index === 0) {
 				anchor.setAttribute('aria-current', 'location');
@@ -61,8 +62,20 @@ class Layout {
 			}
 		});
 
-		//on scroll, update current location in nav
+		//highlight nav item that has been clicked on
+		navAnchors.forEach(anchor => {
+			anchor.addEventListener('click', () => {
+				navAnchors.forEach(anchor => anchor.setAttribute('aria-current', false));
+				anchor.setAttribute('aria-current', 'location');
+			});
+		});
+
+		//on scroll, update current location in nav if we haven't scrolled to the bottom of the page
 		document.addEventListener('scroll', () => {
+			if (window.innerHeight + window.pageYOffset >= document.body.scrollHeight) {
+				return;
+			}
+
 			let bufferedPageTop = window.pageYOffset + window.innerHeight / 6;
 			let possibleLocation;
 


### PR DESCRIPTION
closes #9 

Before:
![before](https://user-images.githubusercontent.com/16777943/43136242-026e9108-8f40-11e8-839c-e4174a2bb2b2.gif)

After:
![after](https://user-images.githubusercontent.com/16777943/43136249-044eea68-8f40-11e8-84c6-5f72dac5cadc.gif)