### PR TITLE
Fix the demo branding hack

### DIFF
--- a/demos/src/demo.js
+++ b/demos/src/demo.js
@@ -2,7 +2,15 @@
 import './../../main.js';
 
 //mega hack because we currently have no way of requesting brands for origami.json dependencies
-document.querySelector('link').href += "&brand=internal";
+[...document.querySelectorAll('link')].forEach(link => {
+	const isBuildServiceLink = (
+		link.href.includes('origami-build.ft.com') ||
+		link.href.includes('ft.com/__origami/service/build')
+	);
+	if (isBuildServiceLink && !link.href.includes('brand=')) {
+		link.href += '&brand=internal';
+	}
+});
 
 document.addEventListener('DOMContentLoaded', () => {
 	document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));


### PR DESCRIPTION
In the build service, the brand _does_ get added to the CSS URL so the
JavaScript is adding it twice. Currently demos are broken and this
should fix it