### PR TITLE
Add in linked headings

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,7 @@
     "o-header-services": "^2.3.0",
     "o-footer-services": "^1.0.2",
     "o-typography": "^5.7.5",
-    "o-fonts": "^3.0.4"
+    "o-fonts": "^3.0.4",
+    "o-visual-effects": "^2.0.3"
   }
 }

--- a/main.scss
+++ b/main.scss
@@ -2,6 +2,7 @@ $o-brand: 'internal';
 
 @import 'o-fonts/main';
 @import 'o-typography/main';
+@import 'o-visual-effects/main';
 @import 'o-header-services/main';
 @import 'o-footer-services/main';
 

--- a/src/js/layout.js
+++ b/src/js/layout.js
@@ -1,9 +1,12 @@
+
+import LinkedHeading from './linked-heading';
+
 class Layout {
 	/**
- * Class constructor.
- * @param {HTMLElement} [layoutElement] - The layout element in the DOM
- * @param {Object} [options={}] - An options object for configuring aspects of the layout
- */
+	 * Class constructor.
+	 * @param {HTMLElement} [layoutElement] - The layout element in the DOM
+	 * @param {Object} [options={}] - An options object for configuring aspects of the layout
+	 */
 	constructor (layoutEl, options) {
 		this.layoutEl = layoutEl;
 
@@ -16,6 +19,8 @@ class Layout {
 
 		this.headings = [...this.layoutEl.querySelectorAll(this.options.navHeadingSelector)]
 			.filter(heading => heading.getAttribute('id'));
+
+		this.linkedHeadings = this.headings.map(heading => new LinkedHeading(heading));
 
 		if (this.options.constructNav) {
 			this.constructNavFromDOM();

--- a/src/js/linked-heading.js
+++ b/src/js/linked-heading.js
@@ -1,0 +1,80 @@
+
+/**
+ * Represents a linked component heading.
+ * @public
+ */
+class LinkedHeading {
+
+	/**
+	 * Class constructor.
+	 * @public
+	 * @param {HTMLElement} headingElement - The heading element in the DOM
+	 * @param {Object} [options={}] - An options object for configuring the linked heading
+	 * @param {String} [options.baseClass="o-layout__linked-heading"] - The class attribute to add to the created link
+	 * @param {String} [options.content="¶"] - The content to add to the created link
+	 * @param {String} [options.title="Link directly to this section of the page"] - The title attribute to add to the created link
+	 */
+	constructor (headingElement, options = {}) {
+		this.headingElement = headingElement;
+		this.id = headingElement.getAttribute('id');
+
+		this.options = Object.assign({}, {
+			baseClass: 'o-layout__linked-heading',
+			content: '¶',
+			title: 'Link directly to this section of the page'
+		}, options);
+
+		this.linkElement = this.constructLinkElement();
+	}
+
+	/**
+	 * Construct the heading link element.
+	 * @private
+	 * @returns {HTMLElement} Returns the new link element
+	 */
+	constructLinkElement () {
+		if (!this.id) {
+			return null;
+		}
+		const headingText = this.headingElement.innerHTML.trim();
+		this.headingElement.classList.add(this.options.baseClass);
+		this.headingElement.innerHTML = `
+			<a href="#${this.id}" title="${this.options.title}" class="${this.options.baseClass}__link">
+				${headingText}
+				<span class="${this.options.baseClass}__label">${this.options.content}</span>
+			</a>
+		`;
+		return this.headingElement.querySelector(`.${this.options.baseClass}__link`);
+	}
+
+	/**
+	 * Initialise linked heading components.
+	 * @public
+	 * @param {(HTMLElement|String)} rootElement - The root element to intialise filter forms in, or a CSS selector for the root element
+	 * @param {Object} [options={}] - An options object for configuring the linked heading. See {@link LinkedHeading#constructor}
+	 * @returns {(LinkedHeading|LinkedHeading[])} Returns the new linked heading component or an array of linked heading components
+	 */
+	static init (rootElement, options = {}) {
+		if (!rootElement) {
+			rootElement = document.body;
+		}
+
+		// If the rootElement isnt an HTMLElement, treat it as a selector
+		if (!(rootElement instanceof HTMLElement)) {
+			rootElement = document.querySelector(rootElement);
+		}
+
+		// If the rootElement is an HTMLElement (ie it was found in the document anywhere)
+		// AND the rootElement has the data-o-component=o-linked-heading then initialise just 1 heading (this one)
+		if (rootElement instanceof HTMLElement && /\bo-linked-heading\b/.test(rootElement.getAttribute('data-o-component'))) {
+			return new LinkedHeading(rootElement, options);
+		}
+
+		// If the rootElement wasn't itself a heading, then find ALL of the child things that have the data-o-component=oLinkedHeading set
+		return Array.from(rootElement.querySelectorAll('[data-o-component="o-linked-heading"]'), rootElement => new LinkedHeading(rootElement, options));
+	}
+
+}
+
+// Exports
+export default LinkedHeading;

--- a/src/scss/_linked-heading.scss
+++ b/src/scss/_linked-heading.scss
@@ -1,0 +1,46 @@
+
+/// Linked Heading
+/// Outputs styles for the linked headings
+///
+/// @param {String} $base-class — base class name for layout
+@mixin oLayoutLinkedHeading ($base-class: $o-layout-class) {
+	.#{$base-class}__linked-heading {
+
+		// Increased specificity needed to counteract
+		// default link styles
+		& &__link,
+		& &__link:visited {
+			color: inherit;
+			text-decoration: none;
+			border-bottom: 0;
+		}
+
+		&__label {
+			@include oTypographySans($scale: 2);
+			color: oColorsGetColorFor(link, text);
+			display: none;
+			user-select: none;
+			font-weight: normal;
+		}
+		&__link:hover &__label {
+			display: inline-block;
+		}
+
+		&:target &__link {
+			animation-delay: 0;
+			animation-duration: 5s;
+			animation-timing-function: $o-visual-effects-transition-fade;
+			animation-name: o-layout-linked-heading-fade;
+		}
+
+	}
+
+	@keyframes o-layout-linked-heading-fade {
+		0% {
+			background-color: oColorsMix('teal', 'white', 15);
+		}
+		100% {
+			background-color: transparent;
+		}
+	}
+}

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -2,8 +2,10 @@
 @import 'mixins';
 @import 'grid';
 @import 'grid-areas';
+@import 'linked-heading';
 
 @mixin oLayout($class: $o-layout-class, $header-logo: null, $footer-logo: null) {
 	@include oLayoutBase($class);
 	@include oLayoutAreas($class, $header-logo, $footer-logo);
+	@include oLayoutLinkedHeading($base-class: $class);
 }

--- a/test/linked-heading.spec.js
+++ b/test/linked-heading.spec.js
@@ -1,0 +1,135 @@
+/* eslint-env mocha */
+
+import LinkedHeading from '../src/js/linked-heading';
+import * as assert from 'proclaim';
+import sinon from 'sinon/pkg/sinon';
+
+sinon.assert.expose(assert, {
+	includeFail: false,
+	prefix: ''
+});
+
+describe('LinkedHeading', () => {
+	let testArea;
+
+	beforeEach(() => {
+		document.body.innerHTML = `<div id="test-area"></div>`;
+		testArea = document.querySelector('#test-area');
+	});
+
+	afterEach(() => {
+		document.body.innerHTML = '';
+	});
+
+	describe('new LinkedHeading(element)', () => {
+		let headingElement;
+		let instance;
+		let originalConstructLinkElement;
+
+		beforeEach(() => {
+			originalConstructLinkElement = LinkedHeading.prototype.constructLinkElement;
+			sinon.stub(LinkedHeading.prototype, 'constructLinkElement').returns('mock-link-element');
+			testArea.innerHTML = '<h2 id="mock-id">Mock Content</h2>';
+			headingElement = testArea.querySelector('h2');
+			instance = new LinkedHeading(headingElement);
+		});
+
+		afterEach(() => {
+			LinkedHeading.prototype.constructLinkElement.restore();
+		});
+
+		it('has a `headingElement` property set to the passed in element', () => {
+			assert.strictEqual(instance.headingElement, headingElement);
+		});
+
+		it('has an `id` property set to the heading element ID', () => {
+			assert.strictEqual(instance.id, 'mock-id');
+		});
+
+		it('has an `options` property set to the default options', () => {
+			assert.deepEqual(instance.options, {
+				baseClass: 'o-layout__linked-heading',
+				content: '¶',
+				title: 'Link directly to this section of the page'
+			});
+		});
+
+		it('has a `linkElement` property set to a constructed link element', () => {
+			assert.calledOnce(LinkedHeading.prototype.constructLinkElement);
+			assert.calledWithExactly(LinkedHeading.prototype.constructLinkElement);
+			assert.strictEqual(instance.linkElement, 'mock-link-element');
+		});
+
+		describe('.constructLinkElement()', () => {
+			let returnValue;
+
+			beforeEach(() => {
+				instance.options.baseClass = 'mock-base-class-option';
+				instance.options.content = 'mock-content-option';
+				instance.options.title = 'mock-title-option';
+				returnValue = originalConstructLinkElement.call(instance);
+			});
+
+			it('sets the heading element HTML', () => {
+				const actualHtml = headingElement.outerHTML.trim().replace(/\s+/g, ' ');
+				const expectedHtml = `
+					<h2 id="mock-id" class="mock-base-class-option">
+						<a href="#mock-id" title="mock-title-option" class="mock-base-class-option__link">
+							Mock Content
+							<span class="mock-base-class-option__label">mock-content-option</span>
+						</a>
+					</h2>
+				`.trim().replace(/\s+/g, ' ');
+				assert.strictEqual(actualHtml, expectedHtml);
+			});
+
+			it('returns the created link element', () => {
+				assert.strictEqual(returnValue, headingElement.querySelector('a'));
+			});
+
+			describe('when the heading does not have an ID', () => {
+
+				beforeEach(() => {
+					delete instance.id;
+					returnValue = originalConstructLinkElement.call(instance);
+				});
+
+				it('returns `null`', () => {
+					assert.isNull(returnValue);
+				});
+
+			});
+
+		});
+
+	});
+
+	describe('new LinkedHeading(element, options)', () => {
+		let headingElement;
+		let instance;
+		let options;
+
+		beforeEach(() => {
+			sinon.stub(LinkedHeading.prototype, 'constructLinkElement').returns('mock-link-element');
+			testArea.innerHTML = '<h2 id="mock-id">Mock Content</h2>';
+			headingElement = testArea.querySelector('h2');
+			options = {
+				baseClass: 'mock-base-class-option',
+				content: 'mock-content-option',
+				title: 'mock-title-option'
+			};
+			instance = new LinkedHeading(headingElement, options);
+		});
+
+		afterEach(() => {
+			LinkedHeading.prototype.constructLinkElement.restore();
+		});
+
+		it('has an `options` property set to the given options', () => {
+			assert.deepEqual(instance.options, options);
+			assert.notStrictEqual(instance.options, options);
+		});
+
+	});
+
+});


### PR DESCRIPTION
Headings with IDs in the layout now get linked, with a pilcrow on hover
which matches the registry behaviour. We've gone with a light teal for
now until we have a better idea which accent colours should be used for
the internal brand.