### PR TITLE
Fix a contrast issue

### DIFF
--- a/src/scss/_grid-areas.scss
+++ b/src/scss/_grid-areas.scss
@@ -156,6 +156,7 @@
 				margin-right: -1em;
 
 				&[aria-current="location"] {
+					color: oColorsGetPaletteColor('teal-30');
 					background: oColorsMix('teal', 'white', 20);
 				}
 			}


### PR DESCRIPTION
The currently selected sidebar anchor doesn't have high enough contrast.
I've set the text colour to teal-30, which is the same as the hover
colour.