### PR TITLE
Use border-box sizing on table so width includes padding.

### DIFF
--- a/demos/src/content/3-party-table.mustache
+++ b/demos/src/content/3-party-table.mustache
@@ -13,7 +13,7 @@
 </ol>
 
 <h2 id="this-is-a-table">This is a table</h2>
-<table class="o-table o-table o-table--row-stripes" data-o-component="o-table">
+<table class="o-table o-table--row-stripes" data-o-component="o-table">
 	<thead>
 		<tr><th>For this</th><th>Use this</th><th>Not these</th><th>Because</th></tr>
 	</thead>
@@ -37,7 +37,7 @@
 	 		<td>JavaScript utils</td>
 	 		<td><a href="https://github.com/lodash/lodash">Lodash</a></td>
 	 		<td>Underscore, lodash-node</td>
-	 		<td>Lodash V3 allows each method to be individually requireable e.g. <code>require('lodash/function/defer')</code>, which is more preferable than requiring the whole library. Lodash is roughly functionally equivalent to Underscore, but generally delivers faster performance, and includes some useful things not available in Underscore. Lodash-node was deprecated with the release of Lodash V3.</td>
+	 		<td>Lodash V3 allows each method to be individually requireable, which is more preferable than requiring the whole library. Lodash is roughly functionally equivalent to Underscore, but generally delivers faster performance, and includes some useful things not available in Underscore. Lodash-node was deprecated with the release of Lodash V3.</td>
 	 	</tr><tr>
 	 		<td>Throttle/debounce</td>
 	 		<td><a href="https://github.com/Financial-Times/o-utils">o-utils</a></td>

--- a/demos/src/content/quickstart-tutorial.mustache
+++ b/demos/src/content/quickstart-tutorial.mustache
@@ -52,13 +52,14 @@
 	</p>
 
 	<p>
-		To do that we need to request the <code>o-buttons</code> CSS from the Build Service:
+		To do that we need to request the <code>o-buttons</code> CSS from the Build Service.
+		Replace "[version-here]" with <a href="https://registry.origami.ft.com/components/o-buttons">the latest version number</a>:
 	</p>
 
 
 	<pre>
 		<code class="o-syntax-highlight--html">
-https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-buttons</code>
+https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-buttons@^[version-here]</code>
 	</pre>
 
 	<p>This request says "give me the CSS for o-buttons at the latest version"</p>
@@ -68,7 +69,7 @@ https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-buttons</cod
 
 	<pre>
 		<code class="o-syntax-highlight--html">
-&lt;link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-buttons"/></code>
+&lt;link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-buttons@^[version-here]"/></code>
 	</pre>
 </div>
 <aside>
@@ -86,11 +87,11 @@ https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-buttons</cod
 
 	<p>For this tutorial though, you need to add the class <code>o-buttons</code> to the <code>&lt;button></code> tag.</p>
 
-	<p>o-buttons has some design variations. Let's apply the <code>standout</code> variation by the adding <code>o-buttons--standout</code> class.</p>
+	<p>o-buttons has some design variations. Let's apply the <code>primary</code> variation by the adding <code>o-buttons--primary</code> class.</p>
 
 	<pre>
 		<code class="o-syntax-highlight--html">
-&lt;button class="o-buttons o-buttons--secondary">Here's a button&lt;/button></code>
+&lt;button class="o-buttons o-buttons--primary">Here's a button&lt;/button></code>
 	</pre>
 
 
@@ -103,14 +104,14 @@ https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-buttons</cod
 
 	<pre>
 		<code class="o-syntax-highlight--html">
-https://www.ft.com/__origami/service/build/v2/bundles/js?modules=o-buttons</code>
+https://www.ft.com/__origami/service/build/v2/bundles/js?modules=o-buttons@^[version-here]</code>
 	</pre>
 
 	<p>Instead of using a <code>&lt;link ...></code> tag, use a <code>&lt;script ...></code> tag.</p>
 
 	<pre>
 		<code class="o-syntax-highlight--html">
-&lt;script async type="javascript" src="https://www.ft.com/__origami/service/build/v2/bundles/js?modules=o-buttons">&lt;/script></code>
+&lt;script async type="javascript" src="https://www.ft.com/__origami/service/build/v2/bundles/js?modules=o-buttons@^[version-here]">&lt;/script></code>
 	</pre>
 
 
@@ -121,12 +122,12 @@ https://www.ft.com/__origami/service/build/v2/bundles/js?modules=o-buttons</code
 &lt;html>
 	&lt;head>
 		&lt;!-- build service links and scripts here -->
-		&lt;script async type="javascript" src="https://www.ft.com/__origami/service/build/v2/bundles/js?modules=o-buttons">&lt;/script>
-		&lt;link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-buttons" />
+		&lt;script async type="javascript" src="https://www.ft.com/__origami/service/build/v2/bundles/js?modules=o-buttons@^[version-here]">&lt;/script>
+		&lt;link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-buttons@^[version-here]" />
 	&lt;/head>
 	&lt;body>
 		Hello!
-		&lt;button class="o-buttons o-buttons--secondary">Here's a button&lt;/button>
+		&lt;button class="o-buttons o-buttons--primary">Here's a button&lt;/button>
 	&lt;/body>
 &lt;/html></code>
 	</pre>

--- a/src/scss/_grid-areas.scss
+++ b/src/scss/_grid-areas.scss
@@ -85,7 +85,6 @@
 		> table {
 			grid-column: 1 / span 2;
 			overflow-x: scroll;
-			padding-right: 1rem;
 			width: 100%;
 		}
 

--- a/src/scss/_grid-areas.scss
+++ b/src/scss/_grid-areas.scss
@@ -85,6 +85,8 @@
 		> table {
 			grid-column: 1 / span 2;
 			overflow-x: scroll;
+			padding-right: 1rem;
+			box-sizing: border-box;
 			width: 100%;
 		}
 


### PR DESCRIPTION
- Use border-box sizing on table so width includes padding.
- Update demo to remove reference to non-existent button and to suggest adding the version of o-button in build service requests.
- Remove `code` block from example table. Table overflows on small viewports with the non-breaking code block. Users should include a responsive table via o-table for such cases.