### PR TITLE
highlight page name in sidebar nav

### DIFF
--- a/src/scss/_grid-areas.scss
+++ b/src/scss/_grid-areas.scss
@@ -133,7 +133,7 @@
 @mixin _oLayoutNavigation($class: $o-layout-class) {
 	.#{$class}__navigation {
 		@include oLayoutBreakPoint($from: M) {
-			border-right: 2px solid oColorsGetPaletteColor('teal');
+			// border-right: 2px solid oColorsGetPaletteColor('teal');
 			border-left: 0;
 			position: sticky;
 			top: $_o-layout-gutter;
@@ -150,16 +150,24 @@
 
 		li {
 			padding-right: 1em;
+			border-right: 2px solid oColorsGetPaletteColor('teal');
 
+			&:first-child {
+				@include oTypographyBold('sans');
+				border-right: 0;
+			}
+
+			&:not(:first-child) {
+				a[aria-current="location"] {
+					color: oColorsGetPaletteColor('teal-30');
+					background: oColorsMix('teal', 'white', 20);
+				}
+			}
+			
 			a {
 				display: inline-block;
 				padding: 0.4em 1em;
 				margin-right: -1em;
-
-				&[aria-current="location"] {
-					color: oColorsGetPaletteColor('teal-30');
-					background: oColorsMix('teal', 'white', 20);
-				}
 			}
 		}
 	}


### PR DESCRIPTION
adds `h1` to the navigation construction, 
highlights the `h1` as the page title in the side bar navigation:

![page-name](https://user-images.githubusercontent.com/16777943/48003683-08980000-e107-11e8-95b7-7d58e5c2082a.gif)
 