### PR TITLE
Remove hidden overflow from main layout area.

### DIFF
--- a/src/scss/_grid-areas.scss
+++ b/src/scss/_grid-areas.scss
@@ -72,7 +72,6 @@
 
 		grid-area: main;
 		align-content: flex-start;
-		overflow: hidden;
 
 		> * {
 			grid-column: 1;


### PR DESCRIPTION
`overflow: hidden` makes `o-layout__main` a "scroll container", which means child elements which use sticky positioning may not work as expected e.g. the scroll arrows of `o-table`.

This is because the sticky elements stick to `o-layout__main`, which has a scrolling box with `overflow: hidden` although it doesn't scroll, rather than the viewport.

Slack context: https://financialtimes.slack.com/archives/C02FU5ARJ/p1542193802090800
Issue: https://github.com/Financial-Times/biz-ops-admin/issues/149
Sticky position info: https://www.w3.org/TR/css-position-3/#sticky-pos