### PR TITLE
Remove body height and prevent header stretching

### DIFF
--- a/src/scss/_grid.scss
+++ b/src/scss/_grid.scss
@@ -5,7 +5,6 @@
 @mixin oLayoutBase ($class: $o-layout-class) {
 	html,
 	body {
-		height: 100%;
 		margin: 0;
 	}
 

--- a/src/scss/_grid.scss
+++ b/src/scss/_grid.scss
@@ -21,7 +21,6 @@
 				"footer footer footer footer footer";
 		};
 
-		grid-column-gap: $_o-layout-gutter;
-		min-height: 100%;
+		min-height: 100vh;
 	}
 }

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -45,7 +45,7 @@
 	box-sizing: border-box;
 
 	display: grid;
-	grid-auto-rows: auto;
+	grid-template-rows: auto auto 1fr auto;
 	grid-template-columns: 100%;
 	grid-gap: $_o-layout-gutter;
 	grid-template-areas:


### PR DESCRIPTION
This PR fixes two issues:

- Setting `height: 100%` on the body and html element meant the document height was always the viewport height, with long content overflowing the document. This caused `o-table` to render incorrectly as it checks the document height.
- When content does not push past the height of the viewport, the header was stretched on mobile rather than just the main content area.

Before:
![screenshot 2018-11-22 at 16 05 45](https://user-images.githubusercontent.com/10405691/48913738-31dbbe80-ee71-11e8-9c95-1fb89f831bf5.png)

After:
![screenshot 2018-11-22 at 16 05 08](https://user-images.githubusercontent.com/10405691/48913744-356f4580-ee71-11e8-9a34-22737f6a749e.png)
