### PR TITLE
fix rule bug

### DIFF
--- a/src/scss/_grid-areas.scss
+++ b/src/scss/_grid-areas.scss
@@ -148,7 +148,11 @@
 
 		li {
 			padding-right: 1em;
-			border-right: 2px solid oColorsGetPaletteColor('teal');
+			border-right: 0;
+
+			@include oLayoutBreakPoint($from: M) {
+				border-right: 2px solid oColorsGetPaletteColor('teal');
+			}
 
 			&.o-layout__navigation-title {
 				@include oTypographyBold('sans');

--- a/src/scss/_grid-areas.scss
+++ b/src/scss/_grid-areas.scss
@@ -147,12 +147,12 @@
 
 
 		li {
-			padding-right: 1em;
-			border-right: 0;
-
 			@include oLayoutBreakPoint($from: M) {
 				border-right: 2px solid oColorsGetPaletteColor('teal');
 			}
+
+			padding-right: 1em;
+			border-right: 0;
 
 			&.o-layout__navigation-title {
 				@include oTypographyBold('sans');


### PR DESCRIPTION
The navigation rule is a little broken on mobile

*Before*
<img width="318" alt="screen shot 2018-12-04 at 15 18 09" src="https://user-images.githubusercontent.com/16777943/49451824-ec57b380-f7d7-11e8-94b6-966334004b40.png">

*After*
<img width="316" alt="screen shot 2018-12-04 at 15 18 16" src="https://user-images.githubusercontent.com/16777943/49451825-ecf04a00-f7d7-11e8-9d56-1c527db6fc82.png">
