### PR TITLE
Make the layout (sidebar + main) grid conform to the container of o-header-services.

### DIFF
--- a/src/scss/_grid.scss
+++ b/src/scss/_grid.scss
@@ -14,7 +14,7 @@
 
 		@include oLayoutBreakPoint($from: M) {
 			grid-template-rows: auto 1fr auto;
-			grid-template-columns: 1fr minmax(auto, 30ch) $_o-layout-main-section-width minmax(20ch, 30ch) 1fr;
+			grid-template-columns: 1fr minmax(auto, $_o-layout-aside-max-width) $_o-layout-main-section-width minmax(20ch, $_o-layout-aside-max-width) 1fr;
 			grid-template-areas:
 				"header header header header header"
 				". sidebar main main ."

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -15,8 +15,10 @@ $o-layout-is-silent: true !default;
 $o-layout-class: o-layout !default;
 
 /// Base layout measurements
-$_o-layout-main-section-width: minmax(30ch, oTypographyMaxLineWidth(3));
 $_o-layout-gutter: 1rem;
+$_o-layout-container-max-width: 1220px; // To align to o-header, which uses o-grid https://github.com/Financial-Times/o-grid/blob/v4.4.4/src/scss/_variables.scss#L92
+$_o-layout-aside-max-width: 30ch;
+$_o-layout-main-section-width: minmax(30ch, calc(#{$_o-layout-container-max-width} - #{$_o-layout-aside-max-width * 2} - #{$_o-layout-gutter * 2}));
 
 /// Breakpoints for responsive layout
 /// @type List


### PR DESCRIPTION
At its widest the layout (sidebar + main) should be 1220px in width, the same width as the navigation, but instead may be wider or shorter dependent on content.

This PR ensures the sidebar + main layout areas equal 1220px when the viewport is wide enough. In the next major release we should swap [1220px for the relevant o-grid variable](https://github.com/Financial-Times/o-layout/issues/38).

For example here, the layout is a little wider than the nav:
<img width="1435" alt="screenshot 2018-12-13 at 11 49 29" src="https://user-images.githubusercontent.com/10405691/49948071-97f4b800-feea-11e8-9a59-ad9c250b7611.png">

But in the demo, the layout is a little more narrow than the nav. 
_Top: layout more narrow than the header, Bottom: corrected in this PR._:
<img width="496" alt="screenshot 2018-12-13 at 15 12 57" src="https://user-images.githubusercontent.com/10405691/49948114-b064d280-feea-11e8-8bea-21ab0f0adfd5.png">

An unintended side effect of updating the sidebar+main width has been a slightly wider aside on smaller viewports, which I think is okay (maybe better even?)
_Top: before, Bottom: after, width a slightly wider aside._:
<img width="1144" alt="screenshot 2018-12-13 at 15 45 56" src="https://user-images.githubusercontent.com/10405691/49949758-4f3efe00-feee-11e8-8bee-cd10f1a2ddec.png">
