### PR TITLE
Remove the ability to customise the base class name `o-layout`.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,8 @@
+# Migration
+
+## Migrating from v2 to v3
+- The ability to [customise the `o-layout` CSS class name has been removed](https://github.com/Financial-Times/origami-proposals/issues/4). The `$class` parameter has been removed from SCSS mixins, and the `baseClass` property has been removed from the JS `options` object. Check your project does not use these parameters and update class names to `o-layout` if needed.
+
+## Migrating from v1 to v2
+
+This major now uses `o-footer-services` v2. Though this does not change anything within `o-layout` directly, please make sure that your footer markup is changed according to the [`o-footer-services` migration guide](https://github.com/Financial-Times/o-footer-services#migration-guide).

--- a/README.md
+++ b/README.md
@@ -9,21 +9,21 @@ It provides:
 
 ## Table of Contents
 
-- [Usage](#usage)
-	- [Markup](#markup)
-		- [Layout Base](#layout-base)
-		- [Navigation and Content](#navigation-and-content)
-		- [Asides](#asides)
-	- [Sass](#sass)
-	- [JavaScript](#javascript)
-		- [Construction](#construction)
-		- [Custom Navigation](#custom-navigation)
+- [Overview](#overview)
+- [Markup](#markup)
+	- [Layout Base](#layout-base)
+	- [Navigation and Content](#navigation-and-content)
+	- [Asides](#asides)
+- [Sass](#sass)
+- [JavaScript](#javascript)
+	- [Construction](#construction)
+	- [Custom Navigation](#custom-navigation)
 - [Migration Guide](#migration-guide)
 - [Contact](#contact)
 - [Licence](#licence)
 
 
-## Usage
+## Overview
 
 `o-layout` provides a grid that has the following structure:
 
@@ -62,11 +62,11 @@ Lists are also styled by default if they are not a component of their own (i.e. 
 You can opt out of default list styling by applying the class: '.o-layout__unstyled-element'.
 The grid does not require the sidebar to maintain its layout.
 
-### Markup
+## Markup
 
 `o-layout` uses CSS Grid Layout, and more specifically [grid template areas](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout/Grid_Template_Areas).
 
-#### Layout Base
+### Layout Base
 The markup below ↓ will generate the ascii grid above ↑.
 
 The main content section will constrain its _immediate_ children to its first column, with the exception of `table`s and `aside`s.
@@ -100,7 +100,7 @@ _Note: `o-layout` styles tables to span two columns automatically. If you want a
 </div>
 ```
 
-#### Navigation and Content
+### Navigation and Content
 Unless the configuration says otherwise, `o-layout` will generate a sidebar navigation, which will rely on presence of `<h2>`s and `<h3>`s with `id`s in the main content section. If this is a feature you want to use, then you don't need to add anything to the sidebar section of `o-layout`.
 
 However, if you would like to customise your sidebar navigation, there are two ways to do this. You can add a data-attribute to your markup, or you can do so [via JavaScript](#custom-navigation)
@@ -147,7 +147,7 @@ If you wish to use headings other than `<h2>` and `<h3>` in the navigation gener
 - <div class="o-layout" data-o-component="o-layout">
 ```
 
-#### Asides
+### Asides
 
 `o-layout` will make content asides literal asides to the content. As long as the aside is an aside element and placed _after_ the content it is an aside to, that element will line up correctly:
 
@@ -185,20 +185,19 @@ If you wish to use headings other than `<h2>` and `<h3>` in the navigation gener
 </div>
 ```
 
-### Sass
-As with all Origami components, o-layout has a [silent mode](http://origami.ft.com/docs/syntax/scss/#silent-styles). To use its compiled CSS (rather than using its mixins with your own Sass) set `$o-layout-is-silent: false;` in your Sass before you import the `o-layout` Sass.
+## Sass
+As with all Origami components, o-layout has a [silent mode](http://origami.ft.com/docs/syntax/scss/#silent-styles). You can include o-layout styles with the `oLayout` mixin:
 
-Otherwise, you can initialise the styling for o-layout with your own classnames, like this:
 ```sass
 @import 'o-layout/main';
 
-@include oLayout($class: my-layout);
+@include oLayout();
 ```
 
-### JavaScript
+## JavaScript
 No code will run automatically unless you are using the Build Service. You must either construct an `o-layout` object or fire an o.DOMContentLoaded event, which `o-layout` listens for.
 
-#### Construction
+### Construction
 
 If you have set up your HTML to use default `o-layout` classes, then you can use the following to initialise your layout:
 ```js
@@ -206,7 +205,7 @@ const oLayout = require('o-layout');
 oLayout.init();
 ```
 
-#### Custom Navigation
+### Custom Navigation
 `o-layout` uses JavaScript to construct the sidebar navigation out of headings (`h1`, `h2` and `h3`) in the content, and to highlight those items depending on the scroll position. This is its default behaviour.
 
 If you would like to define your own navigation, you will need to initialise `o-layout` like this:
@@ -223,20 +222,20 @@ const oLayout = require('o-layout');
 oLayout.init(null, { navHeadingSelector: '.nav-heading' });
 ```
 
-### Migration Guide
+## Migration Guide
 
-#### Migrating from v1.x.x to v2.x.x
+State | Major Version | Last Minor Release | Migration guide |
+:---: | :---: | :---: | :---:
+✨ active | 3 | N/A | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
+⚠ maintained | 2 | 2.2.4 | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
+╳ deprecated | 1 | 1.3.4 | N/A |
 
-This major now uses `o-footer-services` v2. Though this does not change anything within `o-layout` directly, please make sure that your footer markup is changed according to the [`o-footer-services` migration guide](https://github.com/Financial-Times/o-footer-services#migration-guide).
 
----
-
-### Contact
+## Contact
 
 If you have any questions or comments about this component, or need help using it, please either [raise an issue](https://github.com/Financial-Times/o-component-boilerplate/issues), visit [#ft-origami](https://financialtimes.slack.com/messages/ft-origami/) or email [Origami Support](mailto:origami-support@ft.com).
 
-----
 
-### Licence
+## Licence
 
 This software is published by the Financial Times under the [MIT licence](http://opensource.org/licenses/MIT).

--- a/src/js/layout.js
+++ b/src/js/layout.js
@@ -12,7 +12,6 @@ class Layout {
 
 		//Default options
 		this.options = Object.assign({}, {
-			baseClass: 'o-layout',
 			constructNav: true,
 			navHeadingSelector: 'h1, h2, h3'
 		}, options || Layout.getDataAttributes(layoutEl));
@@ -20,14 +19,12 @@ class Layout {
 		this.headings = [...this.layoutEl.querySelectorAll(this.options.navHeadingSelector)]
 			.filter(heading => heading.getAttribute('id'));
 
-		this.linkedHeadings = this.headings.map(heading => new LinkedHeading(heading, {
-			baseClass: `${this.options.baseClass}__linked-heading`,
-		}));
+		this.linkedHeadings = this.headings.map(heading => new LinkedHeading(heading, {}));
 
 		if (this.options.constructNav) {
 			this.constructNavFromDOM();
 		} else {
-			let navigation = document.querySelector(`.${this.options.baseClass}__navigation`);
+			let navigation = document.querySelector(`.o-layout__navigation`);
 			if (navigation) {
 				this.highlightNavItems(navigation);
 			}
@@ -39,17 +36,17 @@ class Layout {
 	 */
 	constructNavFromDOM () {
 		let listItems = Array.from(this.headings, (heading) => {
-			const contentElement = heading.querySelector(`.${this.options.baseClass}__linked-heading__content`);
+			const contentElement = heading.querySelector(`.o-layout__linked-heading__content`);
 			const headingText = (contentElement ? contentElement.textContent : heading.textContent);
 			const pageTitleClass = heading.nodeName === 'H1' ? 'class="o-layout__navigation-title"' : '';
 			return `<li ${pageTitleClass}><a href='#${heading.id}'>${headingText}</a></li>`;
 		});
 
 		let list = document.createElement('ol');
-		list.classList.add(`${this.options.baseClass}__navigation`);
+		list.classList.add(`o-layout__navigation`);
 		list.innerHTML = listItems.join('');
 
-		document.querySelector(`.${this.options.baseClass}__sidebar`).append(list);
+		document.querySelector(`.o-layout__sidebar`).append(list);
 
 		this.highlightNavItems(list);
 	}

--- a/src/js/linked-heading.js
+++ b/src/js/linked-heading.js
@@ -10,7 +10,6 @@ class LinkedHeading {
 	 * @public
 	 * @param {HTMLElement} headingElement - The heading element in the DOM
 	 * @param {Object} [options={}] - An options object for configuring the linked heading
-	 * @param {String} [options.baseClass="o-layout__linked-heading"] - The class attribute to add to the created link
 	 * @param {String} [options.content="¶"] - The content to add to the created link
 	 * @param {String} [options.title="Link directly to this section of the page"] - The title attribute to add to the created link
 	 */
@@ -19,7 +18,6 @@ class LinkedHeading {
 		this.id = headingElement.getAttribute('id');
 
 		this.options = Object.assign({}, {
-			baseClass: 'o-layout__linked-heading',
 			content: '#',
 			title: 'Link directly to this section of the page'
 		}, options);
@@ -37,14 +35,14 @@ class LinkedHeading {
 			return null;
 		}
 		const headingText = this.headingElement.innerHTML.trim();
-		this.headingElement.classList.add(this.options.baseClass);
+		this.headingElement.classList.add('o-layout__linked-heading');
 		this.headingElement.innerHTML = `
-			<a href="#${this.id}" title="${this.options.title}" class="${this.options.baseClass}__link">
-				<span class="${this.options.baseClass}__content">${headingText}</span>
-				<span class="${this.options.baseClass}__label">${this.options.content}</span>
+			<a href="#${this.id}" title="${this.options.title}" class="o-layout__linked-heading__link">
+				<span class="o-layout__linked-heading__content">${headingText}</span>
+				<span class="o-layout__linked-heading__label">${this.options.content}</span>
 			</a>
 		`;
-		return this.headingElement.querySelector(`.${this.options.baseClass}__link`);
+		return this.headingElement.querySelector(`.o-layout__linked-heading__link`);
 	}
 
 	/**

--- a/src/scss/_grid-areas.scss
+++ b/src/scss/_grid-areas.scss
@@ -1,38 +1,32 @@
 /// Layout Areas
 /// Outputs grid grid template areas
-///
-/// @param {String} $class — class name for grid
-@mixin oLayoutAreas($class: $o-layout-class, $header-logo: null, $footer-logo: null) {
-	@include oLayoutAreaHeader($class, $header-logo);
-	@include oLayoutAreaSidebar($class);
-	@include oLayoutAreaMain($class);
-	@include oLayoutAreaFooter($class, $footer-logo);
+@mixin oLayoutAreas($header-logo: null, $footer-logo: null) {
+	@include oLayoutAreaHeader($header-logo);
+	@include oLayoutAreaSidebar();
+	@include oLayoutAreaMain();
+	@include oLayoutAreaFooter($footer-logo);
 }
 
 /// Header Area
 /// Outputs grid header area
-///
-/// @param {String} $class — class name for grid
-@mixin oLayoutAreaHeader($class: $o-layout-class, $logo: null) {
+@mixin oLayoutAreaHeader($logo: null) {
 	@if $logo == null {
 		@include oHeaderServices()
 	} @else {
 		@include oHeaderServices($logo: 'https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1:#{$logo}?source=o-layout');
 	}
 
-	.#{$class}__header {
+	.o-layout__header {
 		grid-area: header;
 	}
 }
 
 /// Sidebar Area
 /// Outputs grid sidebar area
-///
-/// @param {String} $class — class name for grid
-@mixin oLayoutAreaSidebar($class: $o-layout-class) {
-	.#{$class}__sidebar {
+@mixin oLayoutAreaSidebar() {
+	.o-layout__sidebar {
 		@include oTypographySans(1);
-		@include _oLayoutNavigation($class);
+		@include _oLayoutNavigation();
 		@include oLayoutBreakPoint($until: M) {
 			padding: 0 1rem;
 		}
@@ -48,10 +42,8 @@
 
 /// Main Area
 /// Outputs grid main content area
-///
-/// @param {String} $class — class name for grid
-@mixin oLayoutAreaMain($class: $o-layout-class) {
-	.#{$class}__main {
+@mixin oLayoutAreaMain() {
+	.o-layout__main {
 		@include _oLayoutBody;
 		@include oLayoutBreakPoint($until: M) {
 			padding: 0 1rem;
@@ -89,20 +81,20 @@
 			width: 100%;
 		}
 
-		.#{$class}__rule-left {
+		.o-layout__rule-left {
 			@include oLayoutRule('left');
 		}
 
-		.#{$class}__rule-right {
+		.o-layout__rule-right {
 			@include oLayoutRule('right');
 		}
 
-		.#{$class}__main__single-span {
+		.o-layout__main__single-span {
 			grid-column-end: 2;
 		}
 
-		.#{$class}__main--full-span,
-		.#{$class}__main__full-span {
+		.o-layout__main--full-span,
+		.o-layout__main__full-span {
 			grid-column-end: -1;
 		}
 	}
@@ -110,27 +102,23 @@
 
 /// Footer Area
 /// Outputs grid footer area
-///
-/// @param {String} $class — class name for grid
-@mixin oLayoutAreaFooter($class: $o-layout-class, $logo: null) {
+@mixin oLayoutAreaFooter($logo: null) {
 	@include oFooterServicesBase();
 
 	@if $logo != null {
 		@include oFooterServicesWithLogo($logo);
 	}
 
-	.#{$class}__footer {
+	.o-layout__footer {
 		grid-area: footer;
 	}
 }
 
 /// Navigation
 /// Outputs navigation styles
-///
-/// @param {String} $class — class name for grid
 /// @access Private
-@mixin _oLayoutNavigation($class: $o-layout-class) {
-	.#{$class}__navigation {
+@mixin _oLayoutNavigation() {
+	.o-layout__navigation {
 		@include oLayoutBreakPoint($from: M) {
 			border-left: 0;
 			position: sticky;

--- a/src/scss/_grid.scss
+++ b/src/scss/_grid.scss
@@ -1,26 +1,14 @@
 /// Layout Base
 /// Outputs responsive base grid
-///
-/// @param {String} $class — class name for grid
-@mixin oLayoutBase ($class: $o-layout-class) {
+@mixin oLayoutBase() {
 	html,
 	body {
 		margin: 0;
 	}
 
-	.#{$class} {
+	.o-layout {
 		@include _oLayoutGridBase;
 		@include oTypographySize(1);
-
-		@include oLayoutBreakPoint($from: M) {
-			grid-template-rows: auto 1fr auto;
-			grid-template-columns: 1fr minmax(auto, $_o-layout-aside-max-width) $_o-layout-main-section-width minmax(20ch, $_o-layout-aside-max-width) 1fr;
-			grid-template-areas:
-				"header header header header header"
-				". sidebar main main ."
-				"footer footer footer footer footer";
-		};
-
 		min-height: 100vh;
 	}
 }

--- a/src/scss/_linked-heading.scss
+++ b/src/scss/_linked-heading.scss
@@ -1,10 +1,8 @@
 
 /// Linked Heading
 /// Outputs styles for the linked headings
-///
-/// @param {String} $base-class — base class name for layout
-@mixin oLayoutLinkedHeading ($base-class: $o-layout-class) {
-	.#{$base-class}__linked-heading {
+@mixin oLayoutLinkedHeading () {
+	.o-layout__linked-heading {
 
 		// Increased specificity needed to counteract
 		// default link styles

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -53,6 +53,7 @@
 		"main"
 		"footer";
 
+	//sass-lint:disable mixins-before-declarations - Source order matters for media queries. Although @at-root is used anyway, which will always output the media after.
 	@include oLayoutBreakPoint($from: M) {
 		grid-template-rows: auto 1fr auto;
 		grid-template-columns: 1fr minmax(auto, $_o-layout-aside-max-width) $_o-layout-main-section-width minmax(20ch, $_o-layout-aside-max-width) 1fr;
@@ -61,6 +62,7 @@
 			". sidebar main main ."
 			"footer footer footer footer footer";
 	};
+	//sass-lint:enable mixins-before-declarations
 }
 
 /// Base styling for the layout content

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -43,7 +43,6 @@
 	margin: 0;
 	position: relative;
 	box-sizing: border-box;
-
 	display: grid;
 	grid-template-rows: auto auto 1fr auto;
 	grid-template-columns: 100%;
@@ -53,6 +52,15 @@
 		"sidebar"
 		"main"
 		"footer";
+
+	@include oLayoutBreakPoint($from: M) {
+		grid-template-rows: auto 1fr auto;
+		grid-template-columns: 1fr minmax(auto, $_o-layout-aside-max-width) $_o-layout-main-section-width minmax(20ch, $_o-layout-aside-max-width) 1fr;
+		grid-template-areas:
+			"header header header header header"
+			". sidebar main main ."
+			"footer footer footer footer footer";
+	};
 }
 
 /// Base styling for the layout content

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -4,8 +4,8 @@
 @import 'grid-areas';
 @import 'linked-heading';
 
-@mixin oLayout($class: $o-layout-class, $header-logo: null, $footer-logo: null) {
-	@include oLayoutBase($class);
-	@include oLayoutAreas($class, $header-logo, $footer-logo);
-	@include oLayoutLinkedHeading($base-class: $class);
+@mixin oLayout($header-logo: null, $footer-logo: null) {
+	@include oLayoutBase();
+	@include oLayoutAreas($header-logo, $footer-logo);
+	@include oLayoutLinkedHeading();
 }

--- a/test/layout.spec.js
+++ b/test/layout.spec.js
@@ -51,7 +51,6 @@ describe('Layout', () => {
 			assert.notStrictEqual(layout.options, options);
 			assert.deepEqual(layout.options, {
 				constructNav: true,
-				baseClass: 'o-layout',
 				navHeadingSelector: 'h1, h2, h3'
 			});
 		});

--- a/test/linked-heading.spec.js
+++ b/test/linked-heading.spec.js
@@ -48,7 +48,6 @@ describe('LinkedHeading', () => {
 
 		it('has an `options` property set to the default options', () => {
 			assert.deepEqual(instance.options, {
-				baseClass: 'o-layout__linked-heading',
 				content: '#',
 				title: 'Link directly to this section of the page'
 			});
@@ -64,7 +63,6 @@ describe('LinkedHeading', () => {
 			let returnValue;
 
 			beforeEach(() => {
-				instance.options.baseClass = 'mock-base-class-option';
 				instance.options.content = 'mock-content-option';
 				instance.options.title = 'mock-title-option';
 				returnValue = originalConstructLinkElement.call(instance);
@@ -73,10 +71,10 @@ describe('LinkedHeading', () => {
 			it('sets the heading element HTML', () => {
 				const actualHtml = headingElement.outerHTML.trim().replace(/\s+/g, ' ');
 				const expectedHtml = `
-					<h2 id="mock-id" class="mock-base-class-option">
-						<a href="#mock-id" title="mock-title-option" class="mock-base-class-option__link">
-							<span class="mock-base-class-option__content">Mock Content</span>
-							<span class="mock-base-class-option__label">mock-content-option</span>
+					<h2 id="mock-id" class="o-layout">
+						<a href="#mock-id" title="mock-title-option" class="o-layout__link">
+							<span class="o-layout__content">Mock Content</span>
+							<span class="o-layout__label">mock-content-option</span>
 						</a>
 					</h2>
 				`.trim().replace(/\s+/g, ' ');
@@ -114,7 +112,6 @@ describe('LinkedHeading', () => {
 			testArea.innerHTML = '<h2 id="mock-id">Mock Content</h2>';
 			headingElement = testArea.querySelector('h2');
 			options = {
-				baseClass: 'mock-base-class-option',
 				content: 'mock-content-option',
 				title: 'mock-title-option'
 			};

--- a/test/linked-heading.spec.js
+++ b/test/linked-heading.spec.js
@@ -71,10 +71,10 @@ describe('LinkedHeading', () => {
 			it('sets the heading element HTML', () => {
 				const actualHtml = headingElement.outerHTML.trim().replace(/\s+/g, ' ');
 				const expectedHtml = `
-					<h2 id="mock-id" class="o-layout">
-						<a href="#mock-id" title="mock-title-option" class="o-layout__link">
-							<span class="o-layout__content">Mock Content</span>
-							<span class="o-layout__label">mock-content-option</span>
+					<h2 id="mock-id" class="o-layout__linked-heading">
+						<a href="#mock-id" title="mock-title-option" class="o-layout__linked-heading__link">
+							<span class="o-layout__linked-heading__content">Mock Content</span>
+							<span class="o-layout__linked-heading__label">mock-content-option</span>
 						</a>
 					</h2>
 				`.trim().replace(/\s+/g, ' ');


### PR DESCRIPTION
Also updates README and adds a migration guide ready for v3.