### PR TITLE
Use o-grid for container size and media queries.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,9 +14,9 @@
     "tests"
   ],
   "dependencies": {
-    "sass-mq": "^5.0.0",
     "o-typography": "^5.7.5",
     "o-fonts": "^3.2.0",
-    "o-visual-effects": "^2.0.3"
+    "o-visual-effects": "^2.0.3",
+    "o-grid": "^4.4.4"
   }
 }

--- a/main.scss
+++ b/main.scss
@@ -1,6 +1,5 @@
 $o-brand: 'internal';
 
-@import 'sass-mq/mq';
 @import 'o-fonts/main';
 @import 'o-typography/main';
 @import 'o-visual-effects/main';

--- a/src/scss/_grid-areas.scss
+++ b/src/scss/_grid-areas.scss
@@ -21,7 +21,7 @@
 	.o-layout__sidebar {
 		@include oTypographySans(1);
 		@include _oLayoutNavigation();
-		@include oLayoutBreakPoint($until: M) {
+		@include oGridRespondTo($until: M) {
 			padding: 0 1rem;
 		}
 
@@ -39,25 +39,24 @@
 @mixin oLayoutAreaMain() {
 	.o-layout__main {
 		@include _oLayoutBody;
-		@include oLayoutBreakPoint($until: M) {
-			padding: 0 1rem;
-		}
+		padding: 0 1rem;
+		grid-area: main;
 
-		@include oLayoutBreakPoint($from: ML) {
+		//sass-lint:disable mixins-before-declarations - Source order matters for media queries. Although @at-root is used anyway, which will always output the media after.
+		@include oGridRespondTo($from: M) {
 			display: grid;
 			grid-column-gap: $_o-layout-gutter;
 			grid-template-columns: $_o-layout-main-section-width 1fr;
+			padding: 0;
 		}
 
-		@include oLayoutBreakPoint($from: L) {
+		@include oGridRespondTo($from: L) {
 			> aside {
 				grid-column: 2;
 				grid-row: span 3; //hack mchack, need to look into spanning across rows irrespective of siblings
 			}
 		};
-
-		grid-area: main;
-		align-content: flex-start;
+		//sass-lint:enable mixins-before-declarations
 
 		> * {
 			grid-column: 1;
@@ -107,7 +106,7 @@
 /// @access Private
 @mixin _oLayoutNavigation() {
 	.o-layout__navigation {
-		@include oLayoutBreakPoint($from: M) {
+		@include oGridRespondTo($from: M) {
 			border-left: 0;
 			position: sticky;
 			top: $_o-layout-gutter;
@@ -123,7 +122,7 @@
 
 
 		li {
-			@include oLayoutBreakPoint($from: M) {
+			@include oGridRespondTo($from: M) {
 				border-right: 2px solid oColorsGetPaletteColor('teal');
 			}
 

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -1,41 +1,3 @@
-/// Apply styles at a given layout size
-/// Wrapper for the Sass MQ mq() mixin
-///
-/// @link https://git.io/sass-mq Sass MQ documentation
-///
-/// @example
-///  // Turn the color of an element red at medium layout size and up
-///  @include oLayoutBreakPoint(M) {
-///  	element {
-///  		color: red;
-///  	}
-///  }
-///  // Turn the color of an element blue until medium layout
-///  element {
-///  	@include oLayoutBreakPoint($until: M) {
-///  		color: blue;
-///  	}
-///  }
-///  // Turn the color of an element green from small layout until medium layout
-///  element {
-///  	@include oLayoutBreakPoint($from: S, $until: M) {
-///  		color: green;
-///  	}
-///  }
-///
-/// @param {String} from - one of $o-layout-breakpoints
-/// @param {String} until - one of $o-layout-breakpoints
-
-@mixin oLayoutBreakPoint($from: false, $until: false) {
-	@include mq(
-		$from: $from,
-		$until: $until,
-		$breakpoints: $o-layout-breakpoints
-	) {
-		@content;
-	}
-}
-
 /// Base grid
 /// @access Private
 @mixin _oLayoutGridBase () {
@@ -54,7 +16,7 @@
 		"footer";
 
 	//sass-lint:disable mixins-before-declarations - Source order matters for media queries. Although @at-root is used anyway, which will always output the media after.
-	@include oLayoutBreakPoint($from: M) {
+	@include oGridRespondTo($from: M) {
 		grid-template-rows: auto 1fr auto;
 		grid-template-columns: 1fr minmax(auto, $_o-layout-aside-max-width) $_o-layout-main-section-width minmax(20ch, $_o-layout-aside-max-width) 1fr;
 		grid-template-areas:

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -16,7 +16,7 @@ $o-layout-class: o-layout !default;
 
 /// Base layout measurements
 $_o-layout-gutter: 1rem;
-$_o-layout-container-max-width: 1220px; // To align to o-header, which uses o-grid https://github.com/Financial-Times/o-grid/blob/v4.4.4/src/scss/_variables.scss#L92
+$_o-layout-container-max-width: oGridGetMaxWidthForLayout($o-grid-fixed-layout); // To align with o-header-services.
 $_o-layout-aside-max-width: 30ch;
 $_o-layout-main-section-width: minmax(30ch, calc(#{$_o-layout-container-max-width} - #{$_o-layout-aside-max-width * 2} - #{$_o-layout-gutter * 2}));
 


### PR DESCRIPTION
Builds on https://github.com/Financial-Times/o-layout/pull/41, please review that first :)

Closes https://github.com/Financial-Times/o-layout/issues/38