### PR TITLE
Add overview and hero areas

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,8 @@
     "o-typography": "^5.7.5",
     "o-fonts": "^3.2.0",
     "o-visual-effects": "^2.0.3",
-    "o-grid": "^4.4.4"
+    "o-grid": "^4.4.4",
+    "o-colors": "^4.7.9",
+    "o-normalise": "^1.6.2"
   }
 }

--- a/demos/src/landing-layout.mustache
+++ b/demos/src/landing-layout.mustache
@@ -1,13 +1,13 @@
 <div class="o-layout o-layout--landing" data-o-component="o-layout">
     {{> shared/header}}
 
-    <div class="o-layout__hero o-layout__hero--inverse">
+    <div class="o-layout__hero">
         <h1>An Example Landing Page</h1>
         <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
         <!-- o-butons included as a seperate dependancy for demo purposes, see https://registry.origami.ft.com/components/o-buttons -->
         <div>
-            <a class="o-layout__unstyled-element o-buttons o-buttons--big o-buttons--inverse o-buttons--primary" href="#">Do A Thing</a>
-            <a class="o-layout__unstyled-element o-buttons o-buttons--big o-buttons--inverse o-buttons--secondary" href="#">Learn More</a>
+            <a class="o-layout__unstyled-element o-buttons o-buttons--big o-buttons--mono o-buttons--primary" href="#">Do A Thing</a>
+            <a class="o-layout__unstyled-element o-buttons o-buttons--big o-buttons--mono o-buttons--secondary" href="#">Learn More</a>
         </div>
     </div>
 

--- a/demos/src/landing-layout.mustache
+++ b/demos/src/landing-layout.mustache
@@ -1,8 +1,85 @@
 <div class="o-layout o-layout--landing" data-o-component="o-layout">
-	{{> shared/header}}
+    {{> shared/header}}
+
+    <div class="o-layout__hero o-layout__hero--inverse">
+        <h1>An Example Landing Page</h1>
+        <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
+        <!-- o-butons included as a seperate dependancy for demo purposes, see https://registry.origami.ft.com/components/o-buttons -->
+        <div>
+            <a class="o-layout__unstyled-element o-buttons o-buttons--big o-buttons--inverse o-buttons--primary" href="#">Do A Thing</a>
+            <a class="o-layout__unstyled-element o-buttons o-buttons--big o-buttons--inverse o-buttons--secondary" href="#">Learn More</a>
+        </div>
+    </div>
 
 	<div class="o-layout__main" data-o-component="o-syntax-highlight">
-        <h1>An Example Landing Page</h1>
+        <h2>Some Information</h2>
+
+        <div class="o-layout__overview">
+            <div class="o-layout-item">
+                <h3>Great For This</h3>
+                <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Facere quaerat odit perferendis distinctio laboriosam id porro minus eveniet ea reiciendis minima odio eos, molestias consectetur dolor nostrum architecto ducimus deserunt.</p>
+                <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Expedita earum, repudiandae quia consequatur nostrum sit eligendi odio cum aliquid fuga.</p>
+            </div>
+            <div class="o-layout-item">
+                <h3>Good For That</h3>
+                <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Deleniti, numquam!</p>
+                <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Blanditiis, dolor. Autem recusandae vero ut labore? Provident doloremque assumenda iste aperiam quis debitis natus iure aspernatur. Tenetur, suscipit. Officiis, molestias porro?</p>
+            </div>
+            <div class="o-layout-item">
+                <h3>And More</h3>
+                <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Natus, voluptatibus?</p>
+                <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Ab corrupti nemo voluptate aperiam explicabo vitae cupiditate atque fugiat dignissimos, aut in blanditiis perferendis soluta natus ducimus incidunt corporis autem quia?</p>
+            </div>
+        </div>
+
+        <h2>Some Choices To Make</h2>
+
+        <div class="o-layout__overview o-layout__overview--highlight">
+            <div class="o-layout-item">
+                <div class="o-layout-item__content">
+                    <h3>Here's A Thing</h3>
+                    <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Facere quaerat odit perferendis distinctio laboriosam id porro minus eveniet ea reiciendis minima odio eos, molestias consectetur dolor nostrum architecto ducimus deserunt.</p>
+                    <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Expedita earum, repudiandae quia consequatur nostrum sit eligendi odio cum aliquid fuga.</p>
+                </div>
+                <div class="o-layout-item__footer">
+                    <!-- o-butons included as a seperate dependancy for demo purposes, see https://registry.origami.ft.com/components/o-buttons -->
+                    <a class="o-layout__unstyled-element o-buttons o-buttons--big o-buttons--primary" href="#">Take An Action</a>
+                </div>
+            </div>
+            <div class="o-layout-item">
+                <div class="o-layout-item__content">
+                    <h3>And Another</h3>
+                    <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Deleniti, numquam!</p>
+                    <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Blanditiis, dolor. Autem recusandae vero ut labore? Provident doloremque assumenda iste aperiam quis debitis natus iure aspernatur. Tenetur, suscipit. Officiis, molestias porro?</p>
+                </div>
+                <div class="o-layout-item__footer">
+                    <!-- o-butons included as a seperate dependancy for demo purposes, see https://registry.origami.ft.com/components/o-buttons -->
+                    <a class="o-layout__unstyled-element o-buttons o-buttons--big o-buttons--primary" href="#">Do A Thing</a>
+                </div>
+            </div>
+            <div class="o-layout-item">
+                <div class="o-layout-item__content">
+                    <h3>And More Choices</h3>
+                    <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Natus, voluptatibus?</p>
+                    <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Ab corrupti nemo voluptate aperiam explicabo vitae cupiditate atque fugiat dignissimos, aut in blanditiis perferendis soluta natus ducimus incidunt corporis autem quia?</p>
+                </div>
+                <div class="o-layout-item__footer">
+                    <!-- o-butons included as a seperate dependancy for demo purposes, see https://registry.origami.ft.com/components/o-buttons -->
+                    <a class="o-layout__unstyled-element o-buttons o-buttons--big o-buttons--primary" href="#">Do A Different Thing</a>
+                </div>
+            </div>
+            <div class="o-layout-item">
+                <div class="o-layout-item__content">
+                    <h3>What To Do</h3>
+                    <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Natus, voluptatibus?</p>
+                    <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Ab corrupti nemo voluptate aperiam explicabo vitae cupiditate atque fugiat dignissimos, aut in blanditiis perferendis soluta natus ducimus incidunt corporis autem quia?</p>
+                </div>
+                <div class="o-layout-item__footer">
+                    <!-- o-butons included as a seperate dependancy for demo purposes, see https://registry.origami.ft.com/components/o-buttons -->
+                    <a class="o-layout__unstyled-element o-buttons o-buttons--big o-buttons--primary" href="#">Learn More</a>
+                </div>
+            </div>
+	    </div>
         <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Ipsum quam iure quas velit animi sunt aliquid quos esse ea, dolor eaque non repellendus commodi id inventore quae, dicta ducimus? Similique.</p>
         <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Odit, sapiente.</p>
 	</div>

--- a/main.scss
+++ b/main.scss
@@ -1,4 +1,6 @@
 @import 'o-fonts/main';
+@import 'o-colors/main';
+@import 'o-normalise/main';
 @import 'o-typography/main';
 @import 'o-visual-effects/main';
 

--- a/main.scss
+++ b/main.scss
@@ -10,12 +10,17 @@
 @import 'src/scss/grid-areas';
 @import 'src/scss/linked-heading';
 
-@mixin oLayout() {
+/// @param {Map} $opts - A map of configuration, with key "hero-image" (an image for the background of the "hero" area).
+@mixin oLayout($opts: (
+	'hero-image': ''
+)) {
+	$hero-image: map-get($opts, $key: 'hero-image');
+
 	@include oFonts();
 	@include _oLayoutBase();
 	@include _oLayoutDocsGrid();
 	@include _oLayoutLandingGrid();
-	@include _oLayoutAreas();
+	@include _oLayoutAreas($hero-image);
 	@include _oLayoutLinkedHeading();
 }
 

--- a/origami.json
+++ b/origami.json
@@ -20,7 +20,7 @@
 		"sass": "demos/src/demo.scss",
 		"js": "demos/src/demo.js",
 		"documentClasses": "",
-		"dependencies": ["o-table@^7.0.5", "o-syntax-highlight@^1.5.2", "o-tabs@^4.2.0", "o-header-services@^2.3.4", "o-footer-services@^2.0.3"]
+		"dependencies": ["o-table@^7.0.5", "o-syntax-highlight@^1.5.2", "o-tabs@^4.2.0", "o-header-services@^2.3.4", "o-footer-services@^2.0.3", "o-buttons@^5.15.1"]
 	},
 	"demos": [
 		{

--- a/src/scss/_grid-areas.scss
+++ b/src/scss/_grid-areas.scss
@@ -4,6 +4,8 @@
 @mixin _oLayoutAreas() {
 	@include _oLayoutAreaHeader();
 	@include _oLayoutAreaSidebar();
+	@include _oLayoutAreaHero();
+	@include _oLayoutAreaOverview();
 	@include _oLayoutAreaMain();
 	@include _oLayoutAreaFooter();
 }
@@ -26,6 +28,7 @@
 		@include _oLayoutNavigation();
 		@include oGridRespondTo($until: M) {
 			padding: 0 1rem;
+			margin-top: $_o-layout-gutter;
 		}
 
 		grid-area: sidebar;
@@ -33,6 +36,81 @@
 		a {
 			@include oTypographyLink;
 			border: 0;
+		}
+	}
+}
+
+/// Outputs hero area
+/// @access private
+@mixin _oLayoutAreaHero() {
+	.o-layout__hero {
+		@include _oLayoutBody;
+		position: relative;
+		grid-area: hero;
+		padding: $_o-layout-gutter * 2 $_o-layout-gutter;
+		text-align: center;
+		min-height: 30vh;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		align-content: center;
+		justify-items: center;
+		justify-content: center;
+		@if $o-layout-hero-image {
+			background-image: url($o-layout-hero-image);
+		}
+		background-size: 0 0;
+		&::before {
+			position: absolute;
+			content: '';
+			width: 100vw;
+			top: 0;
+			bottom: 0;
+			left: 50%;
+			margin-left: -50vw;
+			background-color: oColorsGetPaletteColor('slate-white-5');
+			background-size: cover;
+			background-image: inherit;
+			z-index: -1;
+		}
+	}
+
+	.o-layout__hero--inverse {
+		&:before {
+			background-color: oColorsGetPaletteColor('slate');
+		}
+		h1, p {
+			color: white;
+		}
+	}
+}
+
+/// Columns for overview items, such as cards.
+/// Outputs overview area
+/// @access private
+@mixin _oLayoutAreaOverview() {
+	.o-layout__overview {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+		grid-gap: $_o-layout-gutter * 3;
+		grid-row-gap: $_o-layout-gutter;
+		margin: 0 0 oTypographySpacingSize(4);
+		.o-layout-item > p:last-child {
+			margin-bottom: 0;
+		}
+	}
+
+	.o-layout__overview--highlight {
+		grid-gap: $_o-layout-gutter;
+		.o-layout-item {
+			display: grid;
+			grid-template-rows: 1fr min-content;
+			background-color: oColorsGetPaletteColor('slate-white-5');
+			padding: $_o-layout-gutter;
+		}
+
+		.o-layout-item__footer {
+			grid-row: 2 / 3;
 		}
 	}
 }

--- a/src/scss/_grid-areas.scss
+++ b/src/scss/_grid-areas.scss
@@ -1,10 +1,11 @@
 /// Layout Areas
 /// Outputs grid grid template areas
+/// @param {String} $hero-image - An image for the "hero" area background.
 /// @access private
-@mixin _oLayoutAreas() {
+@mixin _oLayoutAreas($hero-image: '') {
 	@include _oLayoutAreaHeader();
 	@include _oLayoutAreaSidebar();
-	@include _oLayoutAreaHero();
+	@include _oLayoutAreaHero($hero-image);
 	@include _oLayoutAreaOverview();
 	@include _oLayoutAreaMain();
 	@include _oLayoutAreaFooter();
@@ -41,8 +42,9 @@
 }
 
 /// Outputs hero area
+/// @param {String} $hero-image - An image for the "hero" area background.
 /// @access private
-@mixin _oLayoutAreaHero() {
+@mixin _oLayoutAreaHero($hero-image: '') {
 	.o-layout__hero {
 		@include _oLayoutBody;
 		position: relative;
@@ -56,8 +58,8 @@
 		align-content: center;
 		justify-items: center;
 		justify-content: center;
-		@if $o-layout-hero-image {
-			background-image: url($o-layout-hero-image);
+		@if $hero-image {
+			background-image: url($hero-image);
 		}
 		background-size: 0 0;
 		&::before {
@@ -79,7 +81,9 @@
 		&:before {
 			background-color: oColorsGetPaletteColor('slate');
 		}
-		h1, p {
+
+		h1,
+		p {
 			color: white;
 		}
 	}

--- a/src/scss/_grid-areas.scss
+++ b/src/scss/_grid-areas.scss
@@ -52,6 +52,7 @@
 		padding: $_o-layout-gutter * 2 $_o-layout-gutter;
 		text-align: center;
 		min-height: 30vh;
+		margin: 0 0 oTypographySpacingSize(4);
 		display: flex;
 		flex-direction: column;
 		align-items: center;

--- a/src/scss/_grid-areas.scss
+++ b/src/scss/_grid-areas.scss
@@ -90,9 +90,6 @@
 		grid-gap: $_o-layout-gutter * 3;
 		grid-row-gap: $_o-layout-gutter;
 		margin: 0 0 oTypographySpacingSize(4);
-		.o-layout-item > p:last-child {
-			margin-bottom: 0;
-		}
 	}
 
 	.o-layout__overview--highlight {

--- a/src/scss/_grid-areas.scss
+++ b/src/scss/_grid-areas.scss
@@ -58,6 +58,8 @@
 		align-content: center;
 		justify-items: center;
 		justify-content: center;
+		// The background image is inherited by the pseudo element.
+		// This is to make it easier for a build service users to modify the background image.
 		@if $hero-image {
 			background-image: url($hero-image);
 		}

--- a/src/scss/_grid-areas.scss
+++ b/src/scss/_grid-areas.scss
@@ -76,17 +76,6 @@
 			z-index: -1;
 		}
 	}
-
-	.o-layout__hero--inverse {
-		&:before {
-			background-color: oColorsGetPaletteColor('slate');
-		}
-
-		h1,
-		p {
-			color: white;
-		}
-	}
 }
 
 /// Columns for overview items, such as cards.

--- a/src/scss/_grid.scss
+++ b/src/scss/_grid.scss
@@ -16,7 +16,7 @@
 		min-width: 100%;
 		grid-template-columns: 100%;
 		grid-template-rows: auto 1fr auto;
-		grid-gap: $_o-layout-gutter;
+		grid-column-gap: $_o-layout-gutter;
 		grid-template-areas:
 			"header"
 			"main"
@@ -29,9 +29,15 @@
 /// @access private
 @mixin _oLayoutLandingGrid() {
 	.o-layout.o-layout--landing {
+		grid-template-areas:
+			"header"
+			"hero"
+			"main"
+			"footer";
 		@include oGridRespondTo($from: M) {
 			grid-template-areas:
 				"header header header"
+				". hero ."
 				". main ."
 				"footer footer footer";
 			grid-template-columns: 1fr minmax(auto, $_o-layout-container-max-width) 1fr;

--- a/src/scss/_linked-heading.scss
+++ b/src/scss/_linked-heading.scss
@@ -3,19 +3,19 @@
 /// Outputs styles for the linked headings
 /// @access private
 @mixin _oLayoutLinkedHeading () {
-	.o-layout__linked-heading {
+	.o-layout__linked-heading:not(.o-layout__unstyled-element) {
 
 		// Increased specificity needed to counteract
 		// default link styles
-		& &__link,
-		& &__link:visited {
+		& .o-layout__linked-heading__link,
+		& .o-layout__linked-heading__link:visited {
 			color: inherit;
 			text-decoration: none;
 			border-bottom: 0;
 			position: relative;
 		}
 
-		&__label {
+		.o-layout__linked-heading__label {
 			@include oTypographySans($scale: 2);
 			color: oColorsGetColorFor(link, text);
 			display: none;
@@ -25,11 +25,11 @@
 			right: -0.75em; //keeps the octothorpe in line with the heading if the heading spans a whole grid-column
 		}
 
-		&__link:hover &__label {
+		.o-layout__linked-heading__link:hover .o-layout__linked-heading__label {
 			display: inline-block;
 		}
 
-		&:target &__link {
+		&:target .o-layout__linked-heading__link {
 			animation-delay: 0;
 			animation-duration: 5s;
 			animation-timing-function: $o-visual-effects-transition-fade;

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -3,7 +3,11 @@
 @mixin _oLayoutBody () {
 	@include oTypographySans($scale: 1, $line-height: 1.4);
 
-	a {
+	p {
+		max-width: oTypographyMaxLineWidth($scale: 1, $optimal-characters-per-line: 85);
+	}
+
+	a:not(.o-layout__unstyled-element) {
 		@include oTypographyLink();
 	}
 

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -14,7 +14,3 @@ $_o-layout-gutter: 1rem;
 $_o-layout-container-max-width: oGridGetMaxWidthForLayout($o-grid-fixed-layout); // To align with o-header-services.
 $_o-layout-aside-max-width: 30ch;
 $_o-layout-main-section-width: minmax(30ch, calc(#{$_o-layout-container-max-width} - #{$_o-layout-aside-max-width * 2} - #{$_o-layout-gutter * 2}));
-
-/// The URL for the default hero image.
-/// @access public
-$o-layout-hero-image: '' !default;

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -14,3 +14,7 @@ $_o-layout-gutter: 1rem;
 $_o-layout-container-max-width: oGridGetMaxWidthForLayout($o-grid-fixed-layout); // To align with o-header-services.
 $_o-layout-aside-max-width: 30ch;
 $_o-layout-main-section-width: minmax(30ch, calc(#{$_o-layout-container-max-width} - #{$_o-layout-aside-max-width * 2} - #{$_o-layout-gutter * 2}));
+
+/// The URL for the default hero image.
+/// @access public
+$o-layout-hero-image: '' !default;


### PR DESCRIPTION
**Changes**
- Adds a hero area to the landing page.
- Adds an overview area to the landing page (with highlighted or non-highlighted items). 
- Adds anchor element support to `.o-layout__unstyled-element`, so buttons may be used within body content.

**Upcoming**
- Readme and refactoring still to come.

**Screenshots**

(These screenshots use an [unreleased version of o-typography](https://github.com/Financial-Times/o-typography/pull/166), so may look different locally until that is released.)

<img width="1484" alt="screenshot 2019-01-03 at 14 29 44" src="https://user-images.githubusercontent.com/10405691/50642784-239abb00-0f64-11e9-8cef-bd35cca37f36.png">
<img width="1512" alt="screenshot 2019-01-03 at 14 26 12" src="https://user-images.githubusercontent.com/10405691/50642598-948da300-0f63-11e9-8710-1db33077c563.png">
<img width="512" alt="screenshot 2019-01-03 at 14 29 49" src="https://user-images.githubusercontent.com/10405691/50642801-30b7aa00-0f64-11e9-933b-70b05d76393d.png">

