### PR TITLE
Add class for typography wrapper:

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -9,6 +9,7 @@
 - The ability to [customise the `o-layout` CSS class name has been removed](https://github.com/Financial-Times/origami-proposals/issues/4). The public `$o-layout-class` variable has been removed, the `$class` parameter has been removed from SCSS mixins, and the `baseClass` property has been removed from the JS `options` object. Check your project does not use these parameters and update class names to `o-layout` if needed.
 - `o-layout` no longer includes CSS and JS for `o-header-services` or `o-footer-services`. Include CSS and JS for `o-header-services` in your project, and `o-footer-services` if needed.
 - Required font faces are now output by `o-layout`, so `o-fonts` may be removed as a direct dependancy.
+- Add `o-layout-body` along with `o-layout__main` to apply typography.
 - Previously `o-header-services` markup was modified by adding a `o-layout__header` class. But `o-header-services` markup is now placed, unaltered, within a wrapping `div`.
 ```diff
 <div class="o-layout" data-o-component="o-layout" data-o-layout-construct-nav="false">

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -9,7 +9,7 @@
 - The ability to [customise the `o-layout` CSS class name has been removed](https://github.com/Financial-Times/origami-proposals/issues/4). The public `$o-layout-class` variable has been removed, the `$class` parameter has been removed from SCSS mixins, and the `baseClass` property has been removed from the JS `options` object. Check your project does not use these parameters and update class names to `o-layout` if needed.
 - `o-layout` no longer includes CSS and JS for `o-header-services` or `o-footer-services`. Include CSS and JS for `o-header-services` in your project, and `o-footer-services` if needed.
 - Required font faces are now output by `o-layout`, so `o-fonts` may be removed as a direct dependancy.
-- Add `o-layout-body` along with `o-layout__main` to apply typography.
+- Add `o-layout-typography` along with `o-layout__main` to apply typography.
 - Previously `o-header-services` markup was modified by adding a `o-layout__header` class. But `o-header-services` markup is now placed, unaltered, within a wrapping `div`.
 ```diff
 <div class="o-layout" data-o-component="o-layout" data-o-layout-construct-nav="false">

--- a/demos/src/base-layout.mustache
+++ b/demos/src/base-layout.mustache
@@ -1,7 +1,7 @@
 <div class="o-layout" data-o-component="o-layout">
 	{{> shared/header}}
 
-	<div class="o-layout__main o-layout-body" data-o-component="o-syntax-highlight">
+	<div class="o-layout__main o-layout-typography" data-o-component="o-syntax-highlight">
         <h1>Lorem, ipsum.</h1>
         <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Ipsum quam iure quas velit animi sunt aliquid quos esse ea, dolor eaque non repellendus commodi id inventore quae, dicta ducimus? Similique.</p>
         <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Odit, sapiente.</p>

--- a/demos/src/base-layout.mustache
+++ b/demos/src/base-layout.mustache
@@ -1,7 +1,7 @@
 <div class="o-layout" data-o-component="o-layout">
 	{{> shared/header}}
 
-	<div class="o-layout__main" data-o-component="o-syntax-highlight">
+	<div class="o-layout__main o-layout-body" data-o-component="o-syntax-highlight">
         <h1>Lorem, ipsum.</h1>
         <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Ipsum quam iure quas velit animi sunt aliquid quos esse ea, dolor eaque non repellendus commodi id inventore quae, dicta ducimus? Similique.</p>
         <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Odit, sapiente.</p>

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -1,3 +1,7 @@
 @import '../../main';
 
 @include oLayout();
+
+.demo-button:not(:last-of-type) {
+    margin-right: 1rem;
+}

--- a/demos/src/documentation-layout.mustache
+++ b/demos/src/documentation-layout.mustache
@@ -3,7 +3,7 @@
 
 	<div class="o-layout__sidebar"></div>
 
-	<div class="o-layout__main" data-o-component="o-syntax-highlight">
+	<div class="o-layout__main o-layout-body" data-o-component="o-syntax-highlight">
 		<h1 id="an-example-documentation-layout">Documentation Layout</h1>
 		<h2 id="sidebar-navigation">Sidebar Navigation</h2>
 		<p><code class='o-syntax-highlight--html'>o-layout</code> can generate a sidebar navigation, find out more in the <a href="https://registry.origami.ft.com/components/o-layout/readme">readme</a>.</p>

--- a/demos/src/documentation-layout.mustache
+++ b/demos/src/documentation-layout.mustache
@@ -20,105 +20,111 @@
 		<p>Tables span two columns automatically in the documentation layout (into the aside area).</p>
 		<p>Lorem ipsum dolor sit, amet consectetur adipisicing elit. Aliquam rem libero inventore ab nisi pariatur!</p>
 		<p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Ullam doloribus eum maiores dolor ipsam expedita aut rerum animi soluta veritatis eaque quia quisquam, ratione tenetur facere iste cum quos? Repudiandae?</p>
-		<table class="o-table o-table--horizontal-lines " data-o-component="o-table">
-			<thead>
-				<tr>
-					<th scope="col" role="columnheader">Fruit</th>
-					<th scope="col" role="columnheader">Genus</th>
-					<th scope="col" role="columnheader">Characteristic</th>
-					<th scope="col" role="columnheader" data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost&#xA0;(GBP)</th>
-					<th scope="col" role="columnheader" data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost&#xA0;(EUR)</th>
-				</tr>
-			</thead>
-			<tbody>
-				<tr>
-					<td>Dragonfruit</td>
-					<td>Stenocereus</td>
-					<td>Juicy</td>
-					<td class="o-table__cell--numeric">3</td>
-					<td class="o-table__cell--numeric">2.72</td>
-				</tr>
-				<tr>
-					<td>Durian</td>
-					<td>Durio</td>
-					<td>Smelly</td>
-					<td class="o-table__cell--numeric">1.75</td>
-					<td class="o-table__cell--numeric">1.33</td>
-				</tr>
-				<tr>
-					<td>Naseberry</td>
-					<td>Manilkara</td>
-					<td>Chewy</td>
-					<td class="o-table__cell--numeric">2</td>
-					<td class="o-table__cell--numeric">1.85</td>
-				</tr>
-				<tr>
-					<td>Strawberry</td>
-					<td>Fragaria</td>
-					<td>Sweet</td>
-					<td class="o-table__cell--numeric">1.5</td>
-					<td class="o-table__cell--numeric">1.69</td>
-				</tr>
-				<tr>
-					<td>Apple</td>
-					<td>Malus</td>
-					<td>Crunchy</td>
-					<td class="o-table__cell--numeric">0.5</td>
-					<td class="o-table__cell--numeric">0.56</td>
-				</tr>
-			</tbody>
-		</table>
+		<!-- `table` is temporarily wrapped in a `div` to work around a Firefox bug at time of writing: https://github.com/Financial-Times/o-layout/issues/50  -->
+		<div>
+			<table class="o-table o-table--horizontal-lines " data-o-component="o-table">
+				<thead>
+					<tr>
+						<th scope="col" role="columnheader">Fruit</th>
+						<th scope="col" role="columnheader">Genus</th>
+						<th scope="col" role="columnheader">Characteristic</th>
+						<th scope="col" role="columnheader" data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost&#xA0;(GBP)</th>
+						<th scope="col" role="columnheader" data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost&#xA0;(EUR)</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>Dragonfruit</td>
+						<td>Stenocereus</td>
+						<td>Juicy</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">2.72</td>
+					</tr>
+					<tr>
+						<td>Durian</td>
+						<td>Durio</td>
+						<td>Smelly</td>
+						<td class="o-table__cell--numeric">1.75</td>
+						<td class="o-table__cell--numeric">1.33</td>
+					</tr>
+					<tr>
+						<td>Naseberry</td>
+						<td>Manilkara</td>
+						<td>Chewy</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td class="o-table__cell--numeric">1.85</td>
+					</tr>
+					<tr>
+						<td>Strawberry</td>
+						<td>Fragaria</td>
+						<td>Sweet</td>
+						<td class="o-table__cell--numeric">1.5</td>
+						<td class="o-table__cell--numeric">1.69</td>
+					</tr>
+					<tr>
+						<td>Apple</td>
+						<td>Malus</td>
+						<td>Crunchy</td>
+						<td class="o-table__cell--numeric">0.5</td>
+						<td class="o-table__cell--numeric">0.56</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
 
 		<p>But they may be made not to with the class <code>o-layout__main__single-span</code>:</p>
 
-		<table class="o-table o-table--horizontal-lines o-layout__main__single-span" data-o-component="o-table">
-			<thead>
-				<tr>
-					<th scope="col" role="columnheader">Fruit</th>
-					<th scope="col" role="columnheader">Genus</th>
-					<th scope="col" role="columnheader">Characteristic</th>
-					<th scope="col" role="columnheader" data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost&#xA0;(GBP)</th>
-					<th scope="col" role="columnheader" data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost&#xA0;(EUR)</th>
-				</tr>
-			</thead>
-			<tbody>
-				<tr>
-					<td>Dragonfruit</td>
-					<td>Stenocereus</td>
-					<td>Juicy</td>
-					<td class="o-table__cell--numeric">3</td>
-					<td class="o-table__cell--numeric">2.72</td>
-				</tr>
-				<tr>
-					<td>Durian</td>
-					<td>Durio</td>
-					<td>Smelly</td>
-					<td class="o-table__cell--numeric">1.75</td>
-					<td class="o-table__cell--numeric">1.33</td>
-				</tr>
-				<tr>
-					<td>Naseberry</td>
-					<td>Manilkara</td>
-					<td>Chewy</td>
-					<td class="o-table__cell--numeric">2</td>
-					<td class="o-table__cell--numeric">1.85</td>
-				</tr>
-				<tr>
-					<td>Strawberry</td>
-					<td>Fragaria</td>
-					<td>Sweet</td>
-					<td class="o-table__cell--numeric">1.5</td>
-					<td class="o-table__cell--numeric">1.69</td>
-				</tr>
-				<tr>
-					<td>Apple</td>
-					<td>Malus</td>
-					<td>Crunchy</td>
-					<td class="o-table__cell--numeric">0.5</td>
-					<td class="o-table__cell--numeric">0.56</td>
-				</tr>
-			</tbody>
-		</table>
+		<!-- `table` is temporarily wrapped in a `div` to work around a Firefox bug at time of writing: https://github.com/Financial-Times/o-layout/issues/50  -->
+		<div>
+			<table class="o-table o-table--horizontal-lines o-layout__main__single-span" data-o-component="o-table">
+				<thead>
+					<tr>
+						<th scope="col" role="columnheader">Fruit</th>
+						<th scope="col" role="columnheader">Genus</th>
+						<th scope="col" role="columnheader">Characteristic</th>
+						<th scope="col" role="columnheader" data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost&#xA0;(GBP)</th>
+						<th scope="col" role="columnheader" data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost&#xA0;(EUR)</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>Dragonfruit</td>
+						<td>Stenocereus</td>
+						<td>Juicy</td>
+						<td class="o-table__cell--numeric">3</td>
+						<td class="o-table__cell--numeric">2.72</td>
+					</tr>
+					<tr>
+						<td>Durian</td>
+						<td>Durio</td>
+						<td>Smelly</td>
+						<td class="o-table__cell--numeric">1.75</td>
+						<td class="o-table__cell--numeric">1.33</td>
+					</tr>
+					<tr>
+						<td>Naseberry</td>
+						<td>Manilkara</td>
+						<td>Chewy</td>
+						<td class="o-table__cell--numeric">2</td>
+						<td class="o-table__cell--numeric">1.85</td>
+					</tr>
+					<tr>
+						<td>Strawberry</td>
+						<td>Fragaria</td>
+						<td>Sweet</td>
+						<td class="o-table__cell--numeric">1.5</td>
+						<td class="o-table__cell--numeric">1.69</td>
+					</tr>
+					<tr>
+						<td>Apple</td>
+						<td>Malus</td>
+						<td>Crunchy</td>
+						<td class="o-table__cell--numeric">0.5</td>
+						<td class="o-table__cell--numeric">0.56</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
 
 	</div>
 

--- a/demos/src/documentation-layout.mustache
+++ b/demos/src/documentation-layout.mustache
@@ -3,7 +3,7 @@
 
 	<div class="o-layout__sidebar"></div>
 
-	<div class="o-layout__main o-layout-body" data-o-component="o-syntax-highlight">
+	<div class="o-layout__main o-layout-typography" data-o-component="o-syntax-highlight">
 		<h1 id="an-example-documentation-layout">Documentation Layout</h1>
 		<h2 id="sidebar-navigation">Sidebar Navigation</h2>
 		<p><code class='o-syntax-highlight--html'>o-layout</code> can generate a sidebar navigation, find out more in the <a href="https://registry.origami.ft.com/components/o-layout/readme">readme</a>.</p>

--- a/demos/src/landing-layout.mustache
+++ b/demos/src/landing-layout.mustache
@@ -1,7 +1,7 @@
 <div class="o-layout o-layout--landing" data-o-component="o-layout">
     {{> shared/header}}
 
-    <div class="o-layout__hero o-layout-body">
+    <div class="o-layout__hero o-layout-typography">
         <h1>An Example Landing Page</h1>
         <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
         <!-- o-butons included as a seperate dependancy for demo purposes, see https://registry.origami.ft.com/components/o-buttons -->
@@ -11,7 +11,7 @@
         </div>
     </div>
 
-	<div class="o-layout__main o-layout-body" data-o-component="o-syntax-highlight">
+	<div class="o-layout__main o-layout-typography" data-o-component="o-syntax-highlight">
         <h2>Some Information</h2>
 
         <div class="o-layout__overview">

--- a/demos/src/landing-layout.mustache
+++ b/demos/src/landing-layout.mustache
@@ -6,8 +6,8 @@
         <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
         <!-- o-butons included as a seperate dependancy for demo purposes, see https://registry.origami.ft.com/components/o-buttons -->
         <div>
-            <a class="o-layout__unstyled-element o-buttons o-buttons--big o-buttons--mono o-buttons--primary" href="#">Do A Thing</a>
-            <a class="o-layout__unstyled-element o-buttons o-buttons--big o-buttons--mono o-buttons--secondary" href="#">Learn More</a>
+            <a class="o-layout__unstyled-element demo-button o-buttons o-buttons--big o-buttons--mono o-buttons--primary" href="#">Do A Thing</a>
+            <a class="o-layout__unstyled-element demo-button o-buttons o-buttons--big o-buttons--mono o-buttons--secondary" href="#">Learn More</a>
         </div>
     </div>
 

--- a/demos/src/landing-layout.mustache
+++ b/demos/src/landing-layout.mustache
@@ -1,7 +1,7 @@
 <div class="o-layout o-layout--landing" data-o-component="o-layout">
     {{> shared/header}}
 
-    <div class="o-layout__hero">
+    <div class="o-layout__hero o-layout-body">
         <h1>An Example Landing Page</h1>
         <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
         <!-- o-butons included as a seperate dependancy for demo purposes, see https://registry.origami.ft.com/components/o-buttons -->
@@ -11,7 +11,7 @@
         </div>
     </div>
 
-	<div class="o-layout__main" data-o-component="o-syntax-highlight">
+	<div class="o-layout__main o-layout-body" data-o-component="o-syntax-highlight">
         <h2>Some Information</h2>
 
         <div class="o-layout__overview">

--- a/demos/src/query-layout.mustache
+++ b/demos/src/query-layout.mustache
@@ -1,13 +1,13 @@
 <div class="o-layout o-layout--query" data-o-component="o-layout">
     {{> shared/header}}
 
-    <div class="o-layout__heading o-layout-body">
+    <div class="o-layout__heading o-layout-typography">
 		<h1>Searchable Things</h1>
 		<p>Lorem ipsum, dolor sit amet consectetur adipisicing elit. Consequuntur ipsa illum veniam doloremque ut laborum voluptates saepe dignissimos cupiditate eos.</p>
 		<p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Odit, sapiente.</p>
     </div>
 
-    <div class="o-layout__query-sidebar o-layout-body">
+    <div class="o-layout__query-sidebar o-layout-typography">
 <form action="/components" method="get" class="registry__form registry__container__sticky" data-o-component="o-filter-form" data-o-filter-form-browser-history="true">
 	<fieldset class="o-forms">
 		<label class="o-forms__label">Types</label>
@@ -41,7 +41,7 @@
 </form>
     </div>
 
-	<div class="o-layout__main o-layout-body" data-o-component="o-syntax-highlight">
+	<div class="o-layout__main o-layout-typography" data-o-component="o-syntax-highlight">
 		<h2>Results</h2>
 		<ul>
 			<li>
@@ -65,7 +65,7 @@
 		</ul>
 	</div>
 
-    <div class="o-layout__aside-sidebar o-layout-body" data-o-component="o-syntax-highlight">
+    <div class="o-layout__aside-sidebar o-layout-typography" data-o-component="o-syntax-highlight">
 		<p>Aside Sidebar: Lorem ipsum, dolor sit amet consectetur adipisicing <code class='o-syntax-highlight--html'>o-layout</code> elit. Pariatur beatae, tempora deleniti inventore impedit minus corrupti omnis esse assumenda perspiciatis?</p>
     </div>
 

--- a/demos/src/query-layout.mustache
+++ b/demos/src/query-layout.mustache
@@ -1,13 +1,13 @@
 <div class="o-layout o-layout--query" data-o-component="o-layout">
     {{> shared/header}}
 
-    <div class="o-layout__heading">
+    <div class="o-layout__heading o-layout-body">
 		<h1>Searchable Things</h1>
 		<p>Lorem ipsum, dolor sit amet consectetur adipisicing elit. Consequuntur ipsa illum veniam doloremque ut laborum voluptates saepe dignissimos cupiditate eos.</p>
 		<p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Odit, sapiente.</p>
     </div>
 
-    <div class="o-layout__query-sidebar">
+    <div class="o-layout__query-sidebar o-layout-body">
 <form action="/components" method="get" class="registry__form registry__container__sticky" data-o-component="o-filter-form" data-o-filter-form-browser-history="true">
 	<fieldset class="o-forms">
 		<label class="o-forms__label">Types</label>
@@ -41,7 +41,7 @@
 </form>
     </div>
 
-	<div class="o-layout__main" data-o-component="o-syntax-highlight">
+	<div class="o-layout__main o-layout-body" data-o-component="o-syntax-highlight">
 		<h2>Results</h2>
 		<ul>
 			<li>
@@ -65,7 +65,7 @@
 		</ul>
 	</div>
 
-    <div class="o-layout__aside-sidebar" data-o-component="o-syntax-highlight">
+    <div class="o-layout__aside-sidebar o-layout-body" data-o-component="o-syntax-highlight">
 		<p>Aside Sidebar: Lorem ipsum, dolor sit amet consectetur adipisicing <code class='o-syntax-highlight--html'>o-layout</code> elit. Pariatur beatae, tempora deleniti inventore impedit minus corrupti omnis esse assumenda perspiciatis?</p>
     </div>
 

--- a/main.scss
+++ b/main.scss
@@ -23,6 +23,7 @@
 	@include _oLayoutQueryGrid();
 	@include _oLayoutAreas($hero-image);
 	@include _oLayoutLinkedHeading();
+	@include _oLayoutBody;
 }
 
 @if $o-layout-is-silent == false {

--- a/main.scss
+++ b/main.scss
@@ -23,7 +23,7 @@
 	@include _oLayoutQueryGrid();
 	@include _oLayoutAreas($hero-image);
 	@include _oLayoutLinkedHeading();
-	@include _oLayoutBody;
+	@include _oLayoutTypography;
 }
 
 @if $o-layout-is-silent == false {

--- a/src/scss/_grid-areas.scss
+++ b/src/scss/_grid-areas.scss
@@ -48,7 +48,6 @@
 /// @access private
 @mixin _oLayoutAreaHero($hero-image: '') {
 	.o-layout__hero {
-		@include _oLayoutBody;
 		position: relative;
 		grid-area: hero;
 		padding: $_o-layout-gutter * 2 $_o-layout-gutter;
@@ -115,7 +114,6 @@
 /// @access private
 @mixin _oLayoutAreaMain() {
 	.o-layout__main {
-		@include _oLayoutBody;
 		@include oGridRespondTo($until: M) {
 			padding: 0 1rem;
 		}
@@ -194,7 +192,6 @@
 /// @access private
 @mixin _oLayoutAreaQuerySidebar() {
 	.o-layout__query-sidebar {
-		@include _oLayoutBody;
 		grid-area: query-sidebar;
 		padding: $_o-layout-gutter;
 	}
@@ -206,7 +203,6 @@
 /// @access private
 @mixin _oLayoutAreaAsideSidebar() {
 	.o-layout__aside-sidebar {
-		@include _oLayoutBody;
 		grid-area: aside-sidebar;
 		padding: $_o-layout-gutter;
 	}

--- a/src/scss/_grid.scss
+++ b/src/scss/_grid.scss
@@ -148,7 +148,6 @@
 	}
 
 	.o-layout__heading {
-		@include _oLayoutBody;
 		grid-area: heading;
 		margin-top: $_o-layout-gutter;
 		@include oGridRespondTo($until: M) {

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -1,75 +1,77 @@
 /// Base styling for the layout content
 /// @access private
 @mixin _oLayoutBody () {
-	@include oTypographySans($scale: 1, $line-height: 1.4);
+	.o-layout-body {
+		@include oTypographySans($scale: 1, $line-height: 1.4);
 
-	p {
-		max-width: oTypographyMaxLineWidth($scale: 1, $optimal-characters-per-line: 85);
-	}
+		p {
+			max-width: oTypographyMaxLineWidth($scale: 1, $optimal-characters-per-line: 85);
+		}
 
-	a:not(.o-layout__unstyled-element) {
-		@include oTypographyLink();
-	}
+		a:not(.o-layout__unstyled-element) {
+			@include oTypographyLink();
+		}
 
-	h1	{
-		@include oTypographyProductHeadingLevel1();
-	}
+		h1	{
+			@include oTypographyProductHeadingLevel1();
+		}
 
-	h2 {
-		@include oTypographyProductHeadingLevel2();
-	}
+		h2 {
+			@include oTypographyProductHeadingLevel2();
+		}
 
-	h3 {
-		@include oTypographyProductHeadingLevel3();
-	}
+		h3 {
+			@include oTypographyProductHeadingLevel3();
+		}
 
-	h4 {
-		@include oTypographyProductHeadingLevel4();
-	}
+		h4 {
+			@include oTypographyProductHeadingLevel4();
+		}
 
-	h5 {
-		@include oTypographyProductHeadingLevel5();
-	}
+		h5 {
+			@include oTypographyProductHeadingLevel5();
+		}
 
-	h6 {
-		@include oTypographyProductHeadingLevel6();
-	}
+		h6 {
+			@include oTypographyProductHeadingLevel6();
+		}
 
-	aside {
-		@include _oLayoutRule('left');
-		align-self: flex-start;
-	}
+		aside {
+			@include _oLayoutRule('left');
+			align-self: flex-start;
+		}
 
-	p,
-	ol,
-	ul,
-	pre,
-	aside,
-	table {
-		margin: 0 0 oTypographySpacingSize(4);
-	}
+		p,
+		ol,
+		ul,
+		pre,
+		aside,
+		table {
+			margin: 0 0 oTypographySpacingSize(4);
+		}
 
-	ul:not([data-o-component^="o-"], .o-layout__unstyled-element) {
-		list-style-type: none;
-		position: relative;
-		padding-left: 1.5rem;
+		ul:not([data-o-component^="o-"], .o-layout__unstyled-element) {
+			list-style-type: none;
+			position: relative;
+			padding-left: 1.5rem;
 
-		li {
-			margin-bottom: 0.5em;
+			li {
+				margin-bottom: 0.5em;
 
-			&:before {
-				content: '—';
-				position: absolute;
-				left: 0;
-				color: oColorsGetPaletteColor('teal');
-				font-weight: 900;
+				&:before {
+					content: '—';
+					position: absolute;
+					left: 0;
+					color: oColorsGetPaletteColor('teal');
+					font-weight: 900;
+				}
 			}
 		}
-	}
 
-	ol:not([data-o-component^="o-"], .o-layout__unstyled-element) {
-		position: relative;
-		padding-left: 1.5rem;
+		ol:not([data-o-component^="o-"], .o-layout__unstyled-element) {
+			position: relative;
+			padding-left: 1.5rem;
+		}
 	}
 }
 

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -1,7 +1,7 @@
 /// Base styling for the layout content
 /// @access private
-@mixin _oLayoutBody () {
-	.o-layout-body {
+@mixin _oLayoutTypography () {
+	.o-layout-typography {
 		@include oTypographySans($scale: 1, $line-height: 1.4);
 
 		p {


### PR DESCRIPTION
- Avoids some CSS duplication.
- Makes body typography optional.
- Unfortunately we can't use `.o-typography-wrapper` straight up without removing `.o-layout__unstyled-element` functionality, which makes body content with the odd link-as-a-button difficult for users. 😞 

Thoughts?