### PR TITLE
Discussion Required: Make documentation nav scrollable.

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -85,7 +85,9 @@
 			position: sticky;
 			top: $_o-layout-gutter;
 			text-align: right;
-			margin-top: $_o-layout-gutter;
+			margin: $_o-layout-gutter 0;
+			max-height: calc(100vh - #{$_o-layout-gutter * 2});
+			overflow-y: scroll;
 		}
 
 


### PR DESCRIPTION
This makes the sidebar scrollable in a similar way to the registry, for when there are [loads of nav items](https://origami-test.ft.com/spec/v1/components/). 

I don't think it's a good solution for this sidebar though, and don't think this should be merged, because of the issues below. Open to ideas!

**Here it is looking great:**
![scroll-1](https://user-images.githubusercontent.com/10405691/51195708-8b96bd00-18e5-11e9-9f20-2cbeb5dad9b7.gif)

**But it can be clunky:**
But if you start scrolling the sidebar immediately, without scrolling past the nav, the scroll will stop. It seems like you're at the end. But then if you scroll some more the page goes scrolls and reveals the last portion of the nav. We have this at the moment with the registry but it's less of an issue in that context.

Possible solution: Use JS to update the max-height of the nav 😷 

**No indication:**
There's also no indication that the sidebar is scrollable:
![scroll-indication](https://user-images.githubusercontent.com/10405691/51195932-fcd67000-18e5-11e9-8935-680bdc02410f.gif)

Possible solution 1: A styled scroll indicator (arrows, scrollbar, orther?).
Possible solution 2: Expanding, accordion-like nav. Added benefit is the h2/h3 hierarchy would be clear in the nav.