### PR TITLE
Prevent hero section from stretching when there is little content.

### DIFF
--- a/src/scss/_grid.scss
+++ b/src/scss/_grid.scss
@@ -33,6 +33,7 @@
 			"hero"
 			"main"
 			"footer";
+		grid-template-rows: auto auto 1fr auto;
 		@include oGridRespondTo($from: M) {
 			grid-template-areas:
 				"header header header"


### PR DESCRIPTION
Before, the optional hero is removed but the hero area takes up _all the space_:
<img width="1552" alt="screenshot 2019-01-17 at 15 51 57" src="https://user-images.githubusercontent.com/10405691/51330687-e3612f80-1a6f-11e9-85dc-d571aabcf8ae.png">

After (with the grid highlighted), the hero area takes up no space as the hero is removed:
<img width="1440" alt="screenshot 2019-01-17 at 15 48 38" src="https://user-images.githubusercontent.com/10405691/51330686-e3612f80-1a6f-11e9-9799-c980debe34b5.png">