### PR TITLE
Add muted hero.

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,28 @@ The landing layout is ideal for a homepage or other key category / directory pag
 </div>
 ```
 
+When the landing page is a sub-page of the site, the hero area may conflict with the homepage (e.g. on a category / directory page). To reduce the impact of the hero area on sub pages add the modifier class `layout__header--muted`.
+
+```diff
+ <div class="o-layout o-layout--landing" data-o-component="o-layout">
+ 	 <div class="o-layout__header">
+ 	 	 <!-- Your header & navigation here. -->
+ 	 </div>
++ 	 <div class="o-layout__hero o-layout__hero--muted o-layout-typography">
+- 	 <div class="o-layout__hero o-layout-typography">
+ 	 	 <!-- Your hero content here (optional). -->
+ 	 </div>
+ 	 <div class="o-layout__main o-layout-typography">
+ 	 	 <!-- Your landing page content here. -->
+ 	 </div>
+ 	 <footer class="o-layout__footer">
+ 	 	 <!-- Your footer & navigation here. -->
+ 	 </footer>
+ </div>
+```
+
+## Overview Sections
+
 Within the main content area the landing layout provides an overview section. The overview section is ideal for outlining key points of the landing page.
 
 Any number of items are allowed within an overview section, but will wrap onto a new row if there are more than 4.
@@ -321,21 +343,21 @@ The query layout is intended for search, filter, and result pages.The query layo
 
 ### Medium Viewports
 ```
-┌————————————————————┐
-|       HEADER       |
-├————————————————————┤
-|       |  HEADING   |
-|       ├————————————┤
-|       |            |
-| QUERY |  MAIN      |
-| SIDE  |  CONTENT   |
-| BAR   |            |
-|       ├————————————┤
-|       | ASIDE SIDE |
-|       | BAR        |
-├————————————————————┤
-|       FOOTER       |
-└————————————————————┘
+┌————————————————————————┐
+|          HEADER        |
+├————————————————————————┤
+|       |  HEADING       |
+|       ├————————————————┤
+|       |                |
+| QUERY |  MAIN          |
+| SIDE  |  CONTENT       |
+| BAR   |                |
+|       ├————————————————┤
+|       | ASIDE SIDE     |
+|       | BAR            |
+├————————————————————————┤
+|          FOOTER        |
+└————————————————————————┘
 ```
 
 ### Small Viewports

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ The landing layout is ideal for a homepage or other key category / directory pag
 </div>
 ```
 
-When the landing page is a sub-page of the site, the hero area may create a visual conflict with the homepage (e.g. on a category / directory page). To reduce the impact of the hero area on sub pages add the modifier class `layout__header--muted`.
+When the landing page is a sub-page of the site, the hero area may create a visual conflict with the homepage (e.g. on a category / directory page). To reduce the impact of the hero area on sub pages add the modifier class `o-layout__hero--muted`.
 
 ```diff
  <div class="o-layout o-layout--landing" data-o-component="o-layout">

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ The landing layout is ideal for a homepage or other key category / directory pag
 </div>
 ```
 
-When the landing page is a sub-page of the site, the hero area may conflict with the homepage (e.g. on a category / directory page). To reduce the impact of the hero area on sub pages add the modifier class `layout__header--muted`.
+When the landing page is a sub-page of the site, the hero area may create a visual conflict with the homepage (e.g. on a category / directory page). To reduce the impact of the hero area on sub pages add the modifier class `layout__header--muted`.
 
 ```diff
  <div class="o-layout o-layout--landing" data-o-component="o-layout">

--- a/src/scss/_grid-areas.scss
+++ b/src/scss/_grid-areas.scss
@@ -59,6 +59,17 @@
 			background-image: inherit;
 			z-index: -1;
 		}
+		> *:not(.o-layout__unstyled-element):last-child {
+			margin-bottom: 0;
+		}
+	}
+
+	.o-layout__hero.o-layout__hero--muted {
+		align-items: start;
+		align-content: start;
+		text-align: left;
+		background-image: none;
+		min-height: auto;
 	}
 }
 

--- a/src/scss/_grid-areas.scss
+++ b/src/scss/_grid-areas.scss
@@ -64,6 +64,10 @@
 		}
 	}
 
+	.o-layout__hero:not(.o-layout__hero--muted) h1:not(.o-layout__unstyled-element) {
+		@include oTypographySize($scale: 6);
+	}
+
 	.o-layout__hero.o-layout__hero--muted {
 		align-items: start;
 		align-content: start;


### PR DESCRIPTION
When the hero is used on the homepage and a sub-page, it can be confusing as they look so similar and conflict. Here's an example with the Origami docs:

![kapture 2019-01-17 at 17 31 54](https://user-images.githubusercontent.com/10405691/51337576-60e06c00-1a7f-11e9-8fe2-dd94c8bc55b0.gif)

To tackle that, this PR adds a "muted hero". It is less tall and content is aligned to the left. The `h1` size for the standard hero is also increased to further differentiate the two:

![kapture 2019-01-17 at 17 41 09](https://user-images.githubusercontent.com/10405691/51337695-b74daa80-1a7f-11e9-9b7c-929c6ca3c626.gif)

- I flip-flopped and ended up with a modifier class on the hero rather than using ~`o-layout__header`~ `o-layout__heading` It's maybe less accurate to be called a hero, but I think easier to document and communicate to our developers. It also sticks with the convention of one element to one grid area, with the same name. Thoughts?
- This isn't part of a demo yet. I'm unsure how to demo it effectively. Thoughts? _(I can't wait to have... reactive... demos!)_