### PR TITLE
Header alignment and query page spacing.

### DIFF
--- a/src/scss/_grid-areas.scss
+++ b/src/scss/_grid-areas.scss
@@ -156,7 +156,6 @@
 @mixin _oLayoutAreaQuerySidebar() {
 	.o-layout__query-sidebar {
 		grid-area: query-sidebar;
-		padding: $_o-layout-gutter;
 	}
 }
 
@@ -167,6 +166,5 @@
 @mixin _oLayoutAreaAsideSidebar() {
 	.o-layout__aside-sidebar {
 		grid-area: aside-sidebar;
-		padding: $_o-layout-gutter;
 	}
 }

--- a/src/scss/_grid.scss
+++ b/src/scss/_grid.scss
@@ -158,8 +158,8 @@
 			padding: 0 $_o-layout-gutter;
 			margin: 0;
 			@include oGridRespondTo($from: M) {
-				padding: 0 $_o-layout-gutter;
-				margin: $_o-layout-gutter 0 oTypographySpacingSize(5) 0;
+				padding: 0 $_o-layout-gutter 0;
+				margin: $_o-layout-gutter 0 oTypographySpacingSize(5);
 			}
 		}
 

--- a/src/scss/_grid.scss
+++ b/src/scss/_grid.scss
@@ -147,27 +147,30 @@
 
 		.o-layout__heading {
 			margin-top: $_o-layout-gutter;
-			@include oGridRespondTo($until: M) {
-				padding: 0 $_o-layout-gutter;
+			padding: 0 $_o-layout-gutter;
+			@include oGridRespondTo($from: M) {
+				padding: 0;
 			}
 		}
 
 		.o-layout__query-sidebar {
 			border-right: 1px solid oColorsGetPaletteColor('slate-white-15');
 			padding: 0 $_o-layout-gutter;
-			margin-bottom: oTypographySpacingSize(5);
+			margin: 0;
 			@include oGridRespondTo($from: M) {
-				padding: $_o-layout-gutter;
-				margin-bottom: 0;
+				padding: 0 $_o-layout-gutter;
+				margin: $_o-layout-gutter 0 oTypographySpacingSize(5) 0;
 			}
 		}
 
 		.o-layout__aside-sidebar {
+			padding: 0 $_o-layout-gutter;
 			@include oGridRespondTo($from: M) {
-				margin-left: -$_o-layout-gutter;
+				padding: 0;
 			}
 			@include oGridRespondTo($from: L) {
-				margin-left: 0;
+				margin: $_o-layout-gutter 0;
+				padding: 0 0 0 $_o-layout-gutter;
 				border-left: 1px solid oColorsGetPaletteColor('slate-white-15');
 			}
 		}

--- a/src/scss/_grid.scss
+++ b/src/scss/_grid.scss
@@ -158,7 +158,7 @@
 			padding: 0 $_o-layout-gutter;
 			margin: 0;
 			@include oGridRespondTo($from: M) {
-				padding: 0 $_o-layout-gutter 0;
+				padding: 0 $_o-layout-gutter 0 0;
 				margin: $_o-layout-gutter 0 oTypographySpacingSize(5);
 			}
 		}

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -11,5 +11,5 @@ $o-layout-is-silent: true !default;
 
 /// Base layout measurements
 $_o-layout-gutter: 1rem;
-$_o-layout-container-max-width: oGridGetMaxWidthForLayout($o-grid-fixed-layout); // To align with o-header-services.
+$_o-layout-container-max-width: oGridGetMaxWidthForLayout($o-grid-fixed-layout) - (oGridGutter() * 4); // To align with o-header-services.
 $_o-layout-sidebar-max-width: 16.5rem;


### PR DESCRIPTION
- Corrects some padding on the query page.
- Corrects alignment with the header.

Before the sidebars had too much horizontal padding:
<img width="1069" alt="screenshot 2019-01-18 at 16 25 52" src="https://user-images.githubusercontent.com/10405691/51399515-12de6d80-1b3e-11e9-9859-90f9241f21c5.png">

Now they're better. For added effect the screenshot shows the padding temporarily removed from o-forms too, which will be the case in the next major of o-forms:
<img width="1069" alt="screenshot 2019-01-18 at 16 25 59" src="https://user-images.githubusercontent.com/10405691/51399604-3acdd100-1b3e-11e9-836b-8ab50ce47a52.png">

Page content now aligns with the text of the first heading item (before / after):
<img width="1388" alt="screenshot 2019-01-18 at 16 31 49" src="https://user-images.githubusercontent.com/10405691/51399762-9f892b80-1b3e-11e9-8a91-5473b5204bed.png">
<img width="1387" alt="screenshot 2019-01-18 at 16 31 36" src="https://user-images.githubusercontent.com/10405691/51399767-a2841c00-1b3e-11e9-895a-facda7f74a1c.png">
