### PR TITLE
Hero padding

### DIFF
--- a/src/scss/_grid-areas.scss
+++ b/src/scss/_grid-areas.scss
@@ -74,6 +74,10 @@
 		text-align: left;
 		background-image: none;
 		min-height: auto;
+		@include oGridRespondTo($from: M) {
+			padding-left: 0;
+			padding-right: 0;
+		}
 	}
 }
 


### PR DESCRIPTION
Removes this excess horizontal padding:
<img width="380" alt="screenshot 2019-01-21 at 16 19 23" src="https://user-images.githubusercontent.com/10405691/51486336-559b8200-1d98-11e9-8e3d-7f52c96f185e.png">
