### PR TITLE
WIP option 2: Add modifier

### DIFF
--- a/src/scss/_grid.scss
+++ b/src/scss/_grid.scss
@@ -173,7 +173,7 @@
 
 	}
 
-	.o-layout.o-layout--query.o-layout--aside {
+	.o-layout.o-layout--query.o-layout--aside-sidebar {
 		.o-layout__aside-sidebar {
 			padding: 0 $_o-layout-gutter;
 			@include oGridRespondTo($from: M) {

--- a/src/scss/_grid.scss
+++ b/src/scss/_grid.scss
@@ -111,13 +111,12 @@
 /// @access private
 @mixin _oLayoutQueryGrid() {
 	.o-layout.o-layout--query {
-		grid-template-rows: auto auto auto 1fr auto auto;
+		grid-template-rows: auto auto auto 1fr auto;
 		grid-template-areas:
 			"header"
 			"heading"
 			"query-sidebar"
 			"main"
-			"aside-sidebar"
 			"footer";
 
 		@include oGridRespondTo($from: M) {
@@ -127,18 +126,17 @@
 				"header header header header"
 				". query-sidebar heading ."
 				". query-sidebar main ."
-				". query-sidebar aside-sidebar ."
 				"footer footer footer footer";
 		};
 
 		@include oGridRespondTo($from: L) {
 			grid-template-rows: auto auto 1fr auto;
-			grid-template-columns: 1fr minmax(auto, $_o-layout-sidebar-max-width) minmax(15rem, _getMainMaxWidth($_o-layout-sidebar-max-width, $_o-layout-sidebar-max-width)) minmax(auto, $_o-layout-sidebar-max-width) 1fr;
+			grid-template-columns: 1fr minmax(auto, $_o-layout-sidebar-max-width) minmax(15rem, _getMainMaxWidth($_o-layout-sidebar-max-width)) 1fr;
 			grid-template-areas:
-				"header header header header header"
-				". query-sidebar heading aside-sidebar ."
-				". query-sidebar main aside-sidebar ."
-				"footer footer footer footer footer";
+				"header header header header"
+				". query-sidebar heading ."
+				". query-sidebar main ."
+				"footer footer footer footer";
 		};
 
 		.o-layout__main {
@@ -174,5 +172,37 @@
 				border-left: 1px solid oColorsGetPaletteColor('slate-white-15');
 			}
 		}
+	}
+
+	.o-layout.o-layout--query.o-layout--aside {
+		grid-template-rows: auto auto auto 1fr auto auto;
+		grid-template-areas:
+			"header"
+			"heading"
+			"query-sidebar"
+			"main"
+			"aside-sidebar"
+			"footer";
+
+		@include oGridRespondTo($from: M) {
+			grid-template-rows: auto auto 1fr auto auto;
+			grid-template-columns: 1fr minmax(auto, $_o-layout-sidebar-max-width) minmax(15rem, _getMainMaxWidth($_o-layout-sidebar-max-width)) 1fr;
+			grid-template-areas:
+				"header header header header"
+				". query-sidebar heading ."
+				". query-sidebar main ."
+				". query-sidebar aside-sidebar ."
+				"footer footer footer footer";
+		};
+
+		@include oGridRespondTo($from: L) {
+			grid-template-rows: auto auto 1fr auto;
+			grid-template-columns: 1fr minmax(auto, $_o-layout-sidebar-max-width) minmax(15rem, _getMainMaxWidth($_o-layout-sidebar-max-width, $_o-layout-sidebar-max-width)) minmax(auto, $_o-layout-sidebar-max-width) 1fr;
+			grid-template-areas:
+				"header header header header header"
+				". query-sidebar heading aside-sidebar ."
+				". query-sidebar main aside-sidebar ."
+				"footer footer footer footer footer";
+		};
 	}
 }

--- a/src/scss/_grid.scss
+++ b/src/scss/_grid.scss
@@ -163,6 +163,17 @@
 			}
 		}
 
+		.o-layout__main {
+			grid-area: main / main / main / aside-sidebar;
+		}
+
+		.o-layout__aside-sidebar {
+			display: none;
+		}
+
+	}
+
+	.o-layout.o-layout--query.o-layout--aside {
 		.o-layout__aside-sidebar {
 			padding: 0 $_o-layout-gutter;
 			@include oGridRespondTo($from: M) {

--- a/src/scss/_grid.scss
+++ b/src/scss/_grid.scss
@@ -111,12 +111,13 @@
 /// @access private
 @mixin _oLayoutQueryGrid() {
 	.o-layout.o-layout--query {
-		grid-template-rows: auto auto auto 1fr auto;
+		grid-template-rows: auto auto auto 1fr auto auto;
 		grid-template-areas:
 			"header"
 			"heading"
 			"query-sidebar"
 			"main"
+			"aside-sidebar"
 			"footer";
 
 		@include oGridRespondTo($from: M) {
@@ -126,17 +127,18 @@
 				"header header header header"
 				". query-sidebar heading ."
 				". query-sidebar main ."
+				". query-sidebar aside-sidebar ."
 				"footer footer footer footer";
 		};
 
 		@include oGridRespondTo($from: L) {
 			grid-template-rows: auto auto 1fr auto;
-			grid-template-columns: 1fr minmax(auto, $_o-layout-sidebar-max-width) minmax(15rem, _getMainMaxWidth($_o-layout-sidebar-max-width)) 1fr;
+			grid-template-columns: 1fr minmax(auto, $_o-layout-sidebar-max-width) minmax(15rem, _getMainMaxWidth($_o-layout-sidebar-max-width, $_o-layout-sidebar-max-width)) minmax(auto, $_o-layout-sidebar-max-width) 1fr;
 			grid-template-areas:
-				"header header header header"
-				". query-sidebar heading ."
-				". query-sidebar main ."
-				"footer footer footer footer";
+				"header header header header header"
+				". query-sidebar heading aside-sidebar ."
+				". query-sidebar main aside-sidebar ."
+				"footer footer footer footer footer";
 		};
 
 		.o-layout__main {
@@ -172,37 +174,5 @@
 				border-left: 1px solid oColorsGetPaletteColor('slate-white-15');
 			}
 		}
-	}
-
-	.o-layout.o-layout--query.o-layout--aside {
-		grid-template-rows: auto auto auto 1fr auto auto;
-		grid-template-areas:
-			"header"
-			"heading"
-			"query-sidebar"
-			"main"
-			"aside-sidebar"
-			"footer";
-
-		@include oGridRespondTo($from: M) {
-			grid-template-rows: auto auto 1fr auto auto;
-			grid-template-columns: 1fr minmax(auto, $_o-layout-sidebar-max-width) minmax(15rem, _getMainMaxWidth($_o-layout-sidebar-max-width)) 1fr;
-			grid-template-areas:
-				"header header header header"
-				". query-sidebar heading ."
-				". query-sidebar main ."
-				". query-sidebar aside-sidebar ."
-				"footer footer footer footer";
-		};
-
-		@include oGridRespondTo($from: L) {
-			grid-template-rows: auto auto 1fr auto;
-			grid-template-columns: 1fr minmax(auto, $_o-layout-sidebar-max-width) minmax(15rem, _getMainMaxWidth($_o-layout-sidebar-max-width, $_o-layout-sidebar-max-width)) minmax(auto, $_o-layout-sidebar-max-width) 1fr;
-			grid-template-areas:
-				"header header header header header"
-				". query-sidebar heading aside-sidebar ."
-				". query-sidebar main aside-sidebar ."
-				"footer footer footer footer footer";
-		};
 	}
 }


### PR DESCRIPTION
**🚧 WIP - Makes the aside-sidebar of the query layout optional.** 

**Demo only. Readme and tidy up to come.** [Alternate approach here.](https://github.com/Financial-Times/o-layout/pull/64)

### Good
- Does not require a wrapper like [other approaches](https://github.com/Financial-Times/o-layout/pull/64).
- When the sidebar is not used, there is no excess grid gap like with [other approaches](https://github.com/Financial-Times/o-layout/pull/64).

### Bad
- Complicated to document and implement: Requires a modifier class in addition to the layout modifier class `.o-layout.o-layout--query.o-layout--aside-sidebar`. 
- If the aside element is used without the modifier class things break, so it's hidden instead, which is confusing.
- We keep `_getMainMaxWidth` super grossness.