### PR TITLE
Add support for a navigation with hierarchy.

### DIFF
--- a/demos/src/documentation-layout.mustache
+++ b/demos/src/documentation-layout.mustache
@@ -11,11 +11,13 @@
 		<p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Laudantium, velit? Fugiat, sed doloribus. Neque blanditiis aliquam, ab perspiciatis mollitia nesciunt fugit vitae soluta ducimus eos, aspernatur praesentium iure, aliquid modi.</p>
 		<h2 id="asides">Asides</h2>
 		<p>Asides are also styled and positioned witin the documentation layout.</p>
+		<h3 id="sub-section-1">Sub Section 1</h3>
 		<aside>
 			<h3>Hello, I am an aside.</h3>
 			<p>Lorem ipsum dolor sit, amet consectetur adipisicing elit. Aperiam, numquam.</p>
 		</aside>
 		<p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Vel amet minus quibusdam officia, consequuntur perspiciatis laudantium illum, expedita nostrum corrupti accusantium eligendi doloremque quisquam eos commodi temporibus tempora obcaecati. Inventore omnis blanditiis quia mollitia aperiam quibusdam dignissimos unde molestias ipsam.</p>
+		<h3 id="sub-section-2">Sub Section 2</h3>
 		<ul>
 			<li>List item 1</li>
 			<li>List item 2</li>

--- a/src/js/layout.js
+++ b/src/js/layout.js
@@ -63,15 +63,17 @@ class Layout {
 	 * Construct the sidebar navigation from headings within the DOM.
 	 */
 	constructNavFromDOM () {
-		// Get array of headings. If there are h2 headings followed by h3 headings,
-		// Add a property `subItems` to h2 headings which contains an array of the following h3 headings.
+		// Get an array of headings. If there are h2 headings followed by h3 headings (or lower),
+		// add a property `subItems` to the parent h2 which contains an array of the following smaller headings.
 		const headingsWithHierarchy = Array.from(this.navHeadings).reduce((headings, heading) => {
-			const lastHeading = headings.length ? headings[headings.length - 1] : null;
-			if (!lastHeading) {
+			const supportedHeadings = ['H3', 'H4', 'H5', 'H6'];
+			const parents = headings.filter(heading => heading.nodeName === 'H2');
+			const parent = parents ? parents[parents.length - 1] : null;
+			if (!headings.length) {
 				return [heading];
 			}
-			if(lastHeading.nodeName === 'H2' && heading.nodeName === 'H3') {
-				lastHeading.subItems = lastHeading.subItems ? [...lastHeading.subItems, heading] : [heading];
+			if (parent && supportedHeadings.includes(heading.nodeName)) {
+				parent.subItems = parent.subItems ? [...parent.subItems, heading] : [heading];
 				return headings;
 			}
 			headings.push(heading);

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -91,37 +91,31 @@
 			top: $_o-layout-gutter;
 		}
 	}
+
+	.o-layout__navigation li {
+		list-style: none;
+	}
+
 	.o-layout__navigation ul,
 	.o-layout__navigation ol {
-		border: 0;
-		border-left: 2px solid oColorsGetPaletteColor('teal');
 		padding: 0;
+	}
+
+	.o-layout__navigation > ul,
+	.o-layout__navigation > ol {
+		border: 0;
 		text-align: left;
-		list-style: none;
 		margin: 0 0 oTypographySpacingSize(7);
 
 		@include oGridRespondTo($from: M) {
-			border-left: 0;
 			text-align: right;
 			margin-top: $_o-layout-gutter;
 		}
 
-
 		li {
-			&.o-layout__navigation-title {
-				@include oTypographyBold('sans');
-			}
-
-			&:not(.o-layout__navigation-title) {
-				[aria-current="location"] {
-					color: oColorsGetPaletteColor('teal-30');
-					background: oColorsMix('teal', 'white', 20);
-				}
-				a {
-					@include oGridRespondTo($from: M) {
-						border-right: 2px solid oColorsGetPaletteColor('teal');
-					}
-				}
+			&:not(.o-layout__navigation-title) [aria-current="location"] {
+				color: oColorsGetPaletteColor('teal-30');
+				background: oColorsMix('teal', 'white', 20);
 			}
 
 			a {
@@ -130,12 +124,41 @@
 				border: inherit;
 				display: inline-block;
 				padding: 0.4em 1em;
+				word-wrap: anywhere;
+				overflow-wrap: anywhere;
+				border-color: oColorsGetPaletteColor('teal');
+				border-left: 2px solid;
+				@include oGridRespondTo($from: M) {
+					border-left: 0 solid;
+					border-right: 2px solid;
+				}
+			}
+
+			&.o-layout__navigation-title a {
+				@include oTypographyBold('sans');
+				@include oGridRespondTo($from: M) {
+					border: 0;
+				}
+			}
+
+			// For sub-nav headings, where there is no parent anchor.
+			span {
+				@include oTypographySans(1);
+				display: inline-block;
+				padding: 0.4em 1em;
 			}
 		}
 	}
+
+	// Style sub-nav items.
+	.o-layout__navigation ul li:not(.o-layout__navigation-title) ul a,
+	.o-layout__navigation ol li:not(.o-layout__navigation-title) ol a {
+		border-color: rgba(oColorsGetPaletteColor('teal'), 0.4);
+	}
+
 	@if $query-layout {
-		.o-layout--query .o-layout__navigation ul,
-		.o-layout--query .o-layout__navigation ol {
+		.o-layout--query .o-layout__navigation > ul,
+		.o-layout--query .o-layout__navigation > ol {
 			margin-right: calc(-#{$_o-layout-gutter} - 1px);
 			margin-top: 0;
 		}

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -26,6 +26,7 @@ const docsWithSubHeading = `
 		<h1 id="this-is-a-h1">This is a heading level 1</h2>
 		<h2 id="this-is-a-h2">This is a heading level 2</h2>
 		<h3 id="sub-heading-1">Sub heading 1</h3>
+		<h5 id="sub-heading-1b">Sub heading 1b</h5>
 		<h3 id="sub-heading-2">Sub heading 2</h3>
 		<p>This is some content.</p>
 		<p>This is more content</p>

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -16,6 +16,28 @@ const docs = `
 </div>
 `;
 
+const docsWithSubHeading = `
+<div class="o-layout o-layout--docs" data-o-component="o-layout">
+	<header class="o-layout__header"></header>
+
+	<div class="o-layout__sidebar"></div>
+
+	<div class="o-layout__main">
+		<h1 id="this-is-a-h1">This is a heading level 1</h2>
+		<h2 id="this-is-a-h2">This is a heading level 2</h2>
+		<h3 id="sub-heading-1">Sub heading 1</h3>
+		<h3 id="sub-heading-2">Sub heading 2</h3>
+		<p>This is some content.</p>
+		<p>This is more content</p>
+		<h2 id="this-is-a-second-h2">This is a second heading level 2</h2>
+		<h3 id="sub-heading-a">Sub heading a</h3>
+		<p>This is even more content</p>
+	</div>
+
+	<footer class="o-layout__footer"></footer>
+</div>
+`;
+
 const query = `
 <div class="o-layout o-layout--query" data-o-component="o-layout">
     <div class="o-layout__header"></div>
@@ -34,4 +56,4 @@ const query = `
 </div>
 `;
 
-export default { docs, query };
+export default { docs, query, docsWithSubHeading};

--- a/test/layout.spec.js
+++ b/test/layout.spec.js
@@ -47,14 +47,17 @@ describe('Layout', () => {
 			assert.strictEqual(layout.navHeadings.length, 2, `Expected to find two navigation headings but found ${layout.navHeadings.length}.`);
 		});
 
-		it('constructs a nested navigation when a h3 follows a h2', (done) => {
+		it('constructs a nested navigation when a h3 (or lower) follows a h2', (done) => {
 			document.body.innerHTML = docsWithSubHeading;
 			documentationLayoutElement = document.querySelector('.o-layout--docs');
-			new Layout(documentationLayoutElement);
+			new Layout(documentationLayoutElement, {
+				navHeadingSelector: 'h1, h2, h3, h4, h5, h6'
+			});
 			setTimeout(() => {
+
 				assert.strictEqual(
 					documentationLayoutElement.querySelector('.o-layout__sidebar').innerHTML.replace(/[\n\t]/g, ''),
-					'<nav class="o-layout__navigation"><ol class="o-layout__unstyled-element"><li class="o-layout__unstyled-element o-layout__navigation-title"><a class="o-layout__unstyled-element" href="#this-is-a-h1" aria-current="location">This is a heading level 1</a></li><li class="o-layout__unstyled-element "><a class="o-layout__unstyled-element" href="#this-is-a-h2">This is a heading level 2</a><ol><li><a class="o-layout__unstyled-element" href="#sub-heading-1">Sub heading 1</a></li><li><a class="o-layout__unstyled-element" href="#sub-heading-2">Sub heading 2</a></li></ol></li><li class="o-layout__unstyled-element "><a class="o-layout__unstyled-element" href="#this-is-a-second-h2">This is a second heading level 2</a><ol><li><a class="o-layout__unstyled-element" href="#sub-heading-a">Sub heading a</a></li></ol></li></ol></nav>'
+					'<nav class="o-layout__navigation"><ol class="o-layout__unstyled-element"><li class="o-layout__unstyled-element o-layout__navigation-title"><a class="o-layout__unstyled-element" href="#this-is-a-h1" aria-current="location">This is a heading level 1</a></li><li class="o-layout__unstyled-element "><a class="o-layout__unstyled-element" href="#this-is-a-h2">This is a heading level 2</a><ol><li><a class="o-layout__unstyled-element" href="#sub-heading-1">Sub heading 1</a></li><li><a class="o-layout__unstyled-element" href="#sub-heading-1b">Sub heading 1b</a></li><li><a class="o-layout__unstyled-element" href="#sub-heading-2">Sub heading 2</a></li></ol></li><li class="o-layout__unstyled-element "><a class="o-layout__unstyled-element" href="#this-is-a-second-h2">This is a second heading level 2</a><ol><li><a class="o-layout__unstyled-element" href="#sub-heading-a">Sub heading a</a></li></ol></li></ol></nav>'
 				);
 				done();
 			}, 100);

--- a/test/layout.spec.js
+++ b/test/layout.spec.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha, sinon, proclaim */
 
 import Layout from '../src/js/layout';
-import { docs, query } from './helpers/fixtures';
+import { docs, docsWithSubHeading, query } from './helpers/fixtures';
 import * as assert from 'proclaim';
 import sinon from 'sinon/pkg/sinon';
 
@@ -47,6 +47,19 @@ describe('Layout', () => {
 			assert.strictEqual(layout.navHeadings.length, 2, `Expected to find two navigation headings but found ${layout.navHeadings.length}.`);
 		});
 
+		it('constructs a nested navigation when a h3 follows a h2', (done) => {
+			document.body.innerHTML = docsWithSubHeading;
+			documentationLayoutElement = document.querySelector('.o-layout--docs');
+			new Layout(documentationLayoutElement);
+			setTimeout(() => {
+				assert.strictEqual(
+					documentationLayoutElement.querySelector('.o-layout__sidebar').innerHTML.replace(/[\n\t]/g, ''),
+					'<nav class="o-layout__navigation"><ol class="o-layout__unstyled-element"><li class="o-layout__unstyled-element o-layout__navigation-title"><a class="o-layout__unstyled-element" href="#this-is-a-h1" aria-current="location">This is a heading level 1</a></li><li class="o-layout__unstyled-element "><a class="o-layout__unstyled-element" href="#this-is-a-h2">This is a heading level 2</a><ol><li><a class="o-layout__unstyled-element" href="#sub-heading-1">Sub heading 1</a></li><li><a class="o-layout__unstyled-element" href="#sub-heading-2">Sub heading 2</a></li></ol></li><li class="o-layout__unstyled-element "><a class="o-layout__unstyled-element" href="#this-is-a-second-h2">This is a second heading level 2</a><ol><li><a class="o-layout__unstyled-element" href="#sub-heading-a">Sub heading a</a></li></ol></li></ol></nav>'
+				);
+				done();
+			}, 100);
+		});
+
 		it('does not construct the navigation by default for the query layout', () => {
 			new Layout(queryLayoutElement);
 			assert.strictEqual(queryLayoutElement.querySelector('.o-layout__query-sidebar').innerHTML, '', 'Expected to find no navigation HTML within the query layout sidebar.');
@@ -57,7 +70,6 @@ describe('Layout', () => {
 				constructNav: true
 			});
 			setTimeout(() => {
-				console.log(queryLayoutElement.querySelector('.o-layout__query-sidebar').innerHTML);
 				assert.ok(queryLayoutElement.querySelector('.o-layout__query-sidebar').innerHTML, 'Expected to find navigation HTML within the query layout sidebar.');
 				done();
 			}, 100);


### PR DESCRIPTION
Any `h3`s (or lower, to `h6`) are now shown as sub-items to `h2` items.
<img width="581" alt="screenshot 2019-02-01 at 17 11 59" src="https://user-images.githubusercontent.com/10405691/52138624-9ec7bd80-2645-11e9-9ed7-85a24a0d7ac8.png">

This also allows, in custom navs, for nav headings instead of links:
<img width="316" alt="screenshot 2019-02-01 at 17 20 37" src="https://user-images.githubusercontent.com/10405691/52138682-c9b21180-2645-11e9-98ea-cb36b7e917ad.png">

Which will be useful in the registry:
<img width="295" alt="screenshot 2019-02-01 at 17 21 47" src="https://user-images.githubusercontent.com/10405691/52138717-df273b80-2645-11e9-91e8-7ac34a4c4786.png">
