### PR TITLE
Add min width to query aside sidebar

### DIFF
--- a/src/scss/_grid.scss
+++ b/src/scss/_grid.scss
@@ -166,6 +166,7 @@
 
 		.o-layout__aside-sidebar {
 			@include oGridRespondTo($from: L) {
+				min-width: $_o-layout-sidebar-max-width; // So the sidebar can be deleted, the query area fits to content width.
 				margin: $_o-layout-gutter 0;
 				padding-left: $_o-layout-gutter;
 				border-left: 1px solid oColorsGetPaletteColor('slate-white-15');


### PR DESCRIPTION
Query layout: 

So the aside sidebar may be deleted, its grid area uses `fit-content`. So it doesn't become too narrow we can use `min-width`.