### PR TITLE
Set a width on aside-sidebar

### DIFF
--- a/src/scss/_grid.scss
+++ b/src/scss/_grid.scss
@@ -166,7 +166,7 @@
 
 		.o-layout__aside-sidebar {
 			@include oGridRespondTo($from: L) {
-				min-width: $_o-layout-sidebar-max-width; // So the sidebar can be deleted, the query area fits to content width.
+				width: $_o-layout-sidebar-max-width; // So the sidebar can be deleted, the query area fits to content width.
 				margin: $_o-layout-gutter 0;
 				padding-left: $_o-layout-gutter;
 				border-left: 1px solid oColorsGetPaletteColor('slate-white-15');


### PR DESCRIPTION
`fit-content` is used for the aside sidebar column, so that when the aside sidebar is removed from the dom its column shrinks to nothing allowing the main content to expand. However when content cannot break like code within a `pre` tag the aside becomes way too big. So set a width on the aside element to prevent this. I'm not sure if there's a better way.