### PR TITLE
Do not style heading links as normal links.

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -60,7 +60,7 @@
 @mixin _oLayoutBody () {
 	@include oTypographySans($scale: 1, $line-height: 1.4);
 
-	a:not(.o-layout__unstyled-element) {
+	a:not(.o-layout__unstyled-element):not(.o-layout__linked-heading__link) {
 		@include oTypographyLink();
 	}
 


### PR DESCRIPTION
Fixes linked heading styles. Regressed here: https://github.com/Financial-Times/o-layout/pull/60

Before: 
<img width="1340" alt="screenshot 2019-02-12 at 11 49 58" src="https://user-images.githubusercontent.com/10405691/52633454-58cbee80-2ebc-11e9-92c0-ad93a1c9518d.png">

After: 
<img width="1340" alt="screenshot 2019-02-12 at 11 49 17" src="https://user-images.githubusercontent.com/10405691/52633462-5ff2fc80-2ebc-11e9-8822-05bc528f9b5a.png">
