### PR TITLE
Fix sidebar nav wrapping for long items.

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -126,7 +126,7 @@
 				border: inherit;
 				display: inline-block;
 				padding: 0.4em 1em;
-				// Where supposed `overflow-wrap: anywhere` is better than
+				// Where supported `overflow-wrap: anywhere` is better than
 				// `word-break: break-all` as it only breaks a word where
 				// no otherwise-acceptable break points exist.
 				overflow-wrap: anywhere;

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -126,8 +126,14 @@
 				border: inherit;
 				display: inline-block;
 				padding: 0.4em 1em;
-				word-wrap: anywhere;
+				// Where supposed `overflow-wrap: anywhere` is better than
+				// `word-break: break-all` as it only breaks a word where
+				// no otherwise-acceptable break points exist.
 				overflow-wrap: anywhere;
+				word-break: break-all;
+				@supports (overflow-wrap: anywhere) {
+					word-break: normal;
+				}
 				border-color: oColorsGetPaletteColor('teal');
 				border-left: 2px solid;
 				@include oGridRespondTo($from: M) {


### PR DESCRIPTION
Uses `word-break: break-all` as a fallback when `overflow-wrap: anywhere` is not supported.