### PR TITLE
Do not break sidebar nav words if possible.

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -131,7 +131,7 @@
 				// no otherwise-acceptable break points exist.
 				overflow-wrap: anywhere;
 				word-break: break-all; // For browsers which do not support break-word, or overflow-wrap: anywhere.
-				word-break: break-word;
+				word-break: break-word; // sass-lint:disable-line no-duplicate-properties
 				@supports (overflow-wrap: anywhere) {
 					word-break: normal;
 				}

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -127,10 +127,11 @@
 				display: inline-block;
 				padding: 0.4em 1em;
 				// Where supported `overflow-wrap: anywhere` is better than
-				// `word-break: break-all` as it only breaks a word where
+				// `word-break: break-word` as it only breaks a word where
 				// no otherwise-acceptable break points exist.
 				overflow-wrap: anywhere;
-				word-break: break-all;
+				word-break: break-all; // For browsers which do not support break-word, or overflow-wrap: anywhere.
+				word-break: break-word;
 				@supports (overflow-wrap: anywhere) {
 					word-break: normal;
 				}


### PR DESCRIPTION
For browsers that do not support "overflow-wrap: anywhere", use the non-standrad "word-break: break-word". For browsers that support neither use "word-break: break-all" to ensure there is no overflow in the sidebar nav.