### PR TITLE
Prevent image overflow within the main area.

### DIFF
--- a/src/scss/_grid-areas.scss
+++ b/src/scss/_grid-areas.scss
@@ -124,6 +124,11 @@
 			box-sizing: border-box;
 			max-width: 100%;
 		}
+
+		img {
+			max-width: 100%;
+			display: inline-block;
+		}
 	}
 }
 


### PR DESCRIPTION
E.g.
<img width="1533" alt="Screenshot 2019-03-14 at 14 54 20" src="https://user-images.githubusercontent.com/10405691/54366751-1804f800-4669-11e9-893c-c8664a4da70a.png">
