### PR TITLE
This prevents the double links in linked-heading

### DIFF
--- a/src/js/linked-heading.js
+++ b/src/js/linked-heading.js
@@ -26,13 +26,20 @@ class LinkedHeading {
 	}
 
 	/**
-	 * Construct the heading link element.
+	 * Construct the heading link element. If a link element already exists inside the heading,
+	 * then this method will do nothing
 	 * @private
-	 * @returns {HTMLElement} Returns the new link element
+	 * @returns {HTMLElement} Returns the new link element, or the existing link element if present
 	 */
 	constructLinkElement () {
 		if (!this.id) {
 			return null;
+		}
+
+		// Check for an existing link element
+		const existingAnchor = this.headingElement.querySelector('a');
+		if (existingAnchor) {
+			return existingAnchor;
 		}
 
 		// Create heading anchor.

--- a/test/linked-heading.test.js
+++ b/test/linked-heading.test.js
@@ -107,6 +107,27 @@ describe('LinkedHeading', () => {
 
 			});
 
+			describe('when the heading already contains a link element', () => {
+				let expectedHtml;
+				let existingLinkElement;
+
+				beforeEach(() => {
+					expectedHtml = '<a href="/mock-url">Mock Content</a>';
+					headingElement.innerHTML = expectedHtml;
+					existingLinkElement = headingElement.querySelector('a');
+					returnValue = originalConstructLinkElement.call(instance);
+				});
+
+				it('returns the existing link element', () => {
+					assert.strictEqual(returnValue, existingLinkElement);
+				});
+
+				it('does nothing to the DOM', () => {
+					assert.strictEqual(headingElement.innerHTML, expectedHtml);
+				});
+
+			});
+
 		});
 
 	});


### PR DESCRIPTION
Currently if a heading already contains an anchor, we wrap it in another
anchor. This leads to invalid HTML, and some weird browser behaviour
where both links are attempted to be followed (in Chrome at least)

I think that linked-heading should just ignore the heading element if it
already contains a link. The only potential issue here is whether this
may constitute a breaking change to any of our users, my suspicion is
that it won't - it's technically a bug fix.