### PR TITLE
Add blockquote to the o-layout typography wrapper.

### DIFF
--- a/demos/src/documentation-layout.mustache
+++ b/demos/src/documentation-layout.mustache
@@ -33,6 +33,10 @@
 		<h2 id="tables">Tables</h2>
 		<p>The <code>table</code> element spans both columns automatically, but we recommend you use a responsive <a href="https://registry.origami.ft.com/components/o-table">o-table</a> and apply the <code>o-layout__main__full-span</code> class.</p>
 		<p>Lorem ipsum dolor sit, amet consectetur adipisicing elit. Aliquam rem libero inventore ab nisi pariatur!</p>
+		<blockquote>
+			<p>Blockquote... lorem ipsum dolor sit amet, consectetur adipisicing elit. Omnis ea suscipit iusto perspiciatis harum, qui maxime necessitatibus facilis, quo natus rem accusamus autem! Magnam pariatur, perferendis molestiae et tenetur repudiandae.</p>
+			<footer>by Origami Team</footer>
+		</blockquote>
 		<p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Ullam doloribus eum maiores dolor ipsam expedita aut rerum animi soluta veritatis eaque quia quisquam, ratione tenetur facere iste cum quos? Repudiandae?</p>
 
 		<div class="o-table-container o-layout__main__full-span">

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -74,6 +74,11 @@
 			@include oTypographyListOrdered;
 		}
 
+		blockquote:not(.o-layout__unstyled-element) {
+			@include oTypographyBlockquote;
+			margin: 0 0 oTypographySpacingSize(7); // Override default browser margin to match that of `oTypographyBody`.
+		}
+
 		table {
 			margin: 0 0 oTypographySpacingSize(4);
 		}


### PR DESCRIPTION
We may want to update the blockquote margin within `o-typography`. 
I'll add it to my in-progress review of typography.

**_Demo screenshot:_**

<img width="711" alt="Screenshot 2019-05-08 at 13 57 54" src="https://user-images.githubusercontent.com/10405691/57377021-4c90be00-7199-11e9-8461-92b1d04fc287.png">
