### PR TITLE
Add padding to header permalinks

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -216,7 +216,8 @@
 			font-weight: normal;
 			position: absolute;
 			bottom: 0;
-			right: -1ch; //keeps the octothorpe in line with the heading if the heading spans a whole grid-column
+			right: -1.5ch; // Keeps the octothorpe in line with the heading if the heading spans a whole grid-column
+			padding-left: 0.5ch;
 		}
 
 		.o-layout__linked-heading__link:hover .o-layout__linked-heading__label {


### PR DESCRIPTION
Provides `0.5ch` of space between the header and the octothorpe, while remaining hoverable in the gap.

**Before**

![image](https://user-images.githubusercontent.com/51677/57622964-a4a73600-7586-11e9-8450-979887ec9bf2.png)

**After**

![image](https://user-images.githubusercontent.com/51677/57622952-9ce79180-7586-11e9-8ec0-87cf3d16bc04.png)
