### PR TITLE
Prevent grid property autoprefix.

### DIFF
--- a/src/scss/_grid-areas.scss
+++ b/src/scss/_grid-areas.scss
@@ -84,10 +84,13 @@
 /// @access private
 @mixin _oLayoutAreaOverview() {
 	.o-layout__overview {
+		/* autoprefixer: off */
+		// o-layout does not cater for older `-ms-` versions of the grid spec.
 		display: grid;
 		grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
 		grid-gap: $_o-layout-gutter * 3;
 		grid-row-gap: $_o-layout-gutter;
+		/* autoprefixer: on */
 	}
 
 	.o-layout__overview--actions {
@@ -95,8 +98,11 @@
 		margin-bottom: oSpacingByIncrement(7); // Aligns with <p> margin set by oTypographyBody
 
 		.o-layout-item {
+			/* autoprefixer: off */
+			// o-layout does not cater for older `-ms-` versions of the grid spec.
 			display: grid;
 			grid-template-rows: 1fr min-content;
+			/* autoprefixer: on */
 			background-color: oColorsGetPaletteColor('slate-white-5');
 			padding: $_o-layout-gutter;
 		}

--- a/src/scss/_grid.scss
+++ b/src/scss/_grid.scss
@@ -9,19 +9,22 @@
 
 	.o-layout {
 		position: relative;
+		/* autoprefixer: off */
+		// o-layout does not cater for older `-ms-` versions of the grid spec.
 		display: grid;
-		box-sizing: border-box;
-		min-height: 100vh;
-		max-width: $_o-layout-container-max-width;
-		margin: auto;
 		grid-template-columns: 100%;
 		grid-template-rows: auto 1fr auto;
 		grid-column-gap: $_o-layout-gutter;
-		padding: 0 (oGridGutter() * 2); // To align with o-header-services.
 		grid-template-areas:
 			"header"
 			"main"
 			"footer";
+		/* autoprefixer: on */
+		box-sizing: border-box;
+		min-height: 100vh;
+		max-width: $_o-layout-container-max-width;
+		margin: auto;
+		padding: 0 (oGridGutter() * 2); // To align with o-header-services.
 	}
 
 	.o-layout__footer,


### PR DESCRIPTION
`o-layout` was originally made for internal products who
have a relaxed [browser support policy](https://origami.ft.com/docs/components/compatibility/#internal-products). 
However we can easily provide a more reasonable 
experience for users with older browsers if we disable 
autoprefixing of grid properties -- which often requires 
extra properties to get the right effect.

Added bonus: reduced bundle size.

Before IE11:
<img width="1368" alt="Screenshot 2019-07-05 at 12 19 28" src="https://user-images.githubusercontent.com/10405691/60723023-6b59c980-9f2a-11e9-8fc9-2bc94196b0ac.png">

After IE11:
<img width="1368" alt="Screenshot 2019-07-05 at 12 19 22" src="https://user-images.githubusercontent.com/10405691/60723037-76145e80-9f2a-11e9-9429-8e3352cc765a.png">
