### PR TITLE
Update `o-layout__main__single-span` and `...full-span` docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ On large viewports the main content area (`o-layout__main`) is split into two co
 
 Most content is placed into column 1 by default. The exceptions are the `aside` element, which is placed in column 2; and the `table` element, which spans both columns.
 
-Add the class `o-layout__main__single-span` to constrain elements to column 1. Use `o-layout__main__full-span` to expand elements to span both columns.
+Use a containing `div` with class `o-layout__main__single-span` to constrain elements to column 1. Use a `o-layout__main__full-span` container to expand elements to span both columns.
 
 
 ```html
@@ -92,14 +92,18 @@ Add the class `o-layout__main__single-span` to constrain elements to column 1. U
 	<!-- Most content is placed in column 1 -->
 	<h2>A Title</h2>
 	<p>Some content.</p>
-	<!-- Asides are placed in column 2 -->
+	<!-- Asides are placed in column 2 by default -->
 	<aside>An aside</aside>
-	<!-- Tables span columns 1 & 2 -->
+	<!-- Tables span columns 1 & 2 by default -->
 	<table></table>
 	<!-- The class "o-layout__main__single-span" constrains elements to column 1 -->
-	<table class="o-layout__main__single-span"></table>
+	<div class="o-layout__main__single-span">
+		<!-- Your elements -->
+	</div>
 	<!-- The class "o-layout__main__full-span" expands elements to span columns 1 & 2 -->
-	<div class="o-layout__main__full-span"></div>
+	<div class="o-layout__main__full-span">
+		<!-- Your elements -->
+	</div>
 </div>
 ```
 

--- a/demos/src/documentation-layout.mustache
+++ b/demos/src/documentation-layout.mustache
@@ -39,57 +39,59 @@
 		</blockquote>
 		<p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Ullam doloribus eum maiores dolor ipsam expedita aut rerum animi soluta veritatis eaque quia quisquam, ratione tenetur facere iste cum quos? Repudiandae?</p>
 
-		<div class="o-table-container o-layout__main__full-span">
-			<div class="o-table-overlay-wrapper">
-				<div class="o-table-scroll-wrapper">
-					<table class="o-table o-table--horizontal-lines o-table--responsive-overflow" data-o-component="o-table" data-o-table-responsive="overflow">
-						<thead>
-							<tr>
-								<th scope="col" role="columnheader">Fruit</th>
-								<th scope="col" role="columnheader">Genus</th>
-								<th scope="col" role="columnheader">Characteristic</th>
-								<th scope="col" role="columnheader" data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost&#xA0;(GBP)</th>
-								<th scope="col" role="columnheader" data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost&#xA0;(EUR)</th>
-							</tr>
-						</thead>
-						<tbody>
-							<tr>
-								<td>Dragonfruit</td>
-								<td>Stenocereus</td>
-								<td>Juicy</td>
-								<td class="o-table__cell--numeric">3</td>
-								<td class="o-table__cell--numeric">2.72</td>
-							</tr>
-							<tr>
-								<td>Durian</td>
-								<td>Durio</td>
-								<td>Smelly</td>
-								<td class="o-table__cell--numeric">1.75</td>
-								<td class="o-table__cell--numeric">1.33</td>
-							</tr>
-							<tr>
-								<td>Naseberry</td>
-								<td>Manilkara</td>
-								<td>Chewy</td>
-								<td class="o-table__cell--numeric">2</td>
-								<td class="o-table__cell--numeric">1.85</td>
-							</tr>
-							<tr>
-								<td>Strawberry</td>
-								<td>Fragaria</td>
-								<td>Sweet</td>
-								<td class="o-table__cell--numeric">1.5</td>
-								<td class="o-table__cell--numeric">1.69</td>
-							</tr>
-							<tr>
-								<td>Apple</td>
-								<td>Malus</td>
-								<td>Crunchy</td>
-								<td class="o-table__cell--numeric">0.5</td>
-								<td class="o-table__cell--numeric">0.56</td>
-							</tr>
-						</tbody>
-					</table>
+		<div class="o-layout__main__full-span">
+			<div class="o-table-container">
+				<div class="o-table-overlay-wrapper">
+					<div class="o-table-scroll-wrapper">
+						<table class="o-table o-table--horizontal-lines o-table--responsive-overflow" data-o-component="o-table" data-o-table-responsive="overflow">
+							<thead>
+								<tr>
+									<th scope="col" role="columnheader">Fruit</th>
+									<th scope="col" role="columnheader">Genus</th>
+									<th scope="col" role="columnheader">Characteristic</th>
+									<th scope="col" role="columnheader" data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost&#xA0;(GBP)</th>
+									<th scope="col" role="columnheader" data-o-table-data-type="numeric" class="o-table__cell--numeric">Cost&#xA0;(EUR)</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>Dragonfruit</td>
+									<td>Stenocereus</td>
+									<td>Juicy</td>
+									<td class="o-table__cell--numeric">3</td>
+									<td class="o-table__cell--numeric">2.72</td>
+								</tr>
+								<tr>
+									<td>Durian</td>
+									<td>Durio</td>
+									<td>Smelly</td>
+									<td class="o-table__cell--numeric">1.75</td>
+									<td class="o-table__cell--numeric">1.33</td>
+								</tr>
+								<tr>
+									<td>Naseberry</td>
+									<td>Manilkara</td>
+									<td>Chewy</td>
+									<td class="o-table__cell--numeric">2</td>
+									<td class="o-table__cell--numeric">1.85</td>
+								</tr>
+								<tr>
+									<td>Strawberry</td>
+									<td>Fragaria</td>
+									<td>Sweet</td>
+									<td class="o-table__cell--numeric">1.5</td>
+									<td class="o-table__cell--numeric">1.69</td>
+								</tr>
+								<tr>
+									<td>Apple</td>
+									<td>Malus</td>
+									<td>Crunchy</td>
+									<td class="o-table__cell--numeric">0.5</td>
+									<td class="o-table__cell--numeric">0.56</td>
+								</tr>
+							</tbody>
+						</table>
+					</div>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
To avoid styles clashing, `o-layout__main__single-span` and
`o-layout__main__full-span` should be used as a container.

See: https://github.com/Financial-Times/o-layout/pull/98