### PR TITLE
Have the active heading change when it passes the first third of the viewport instead of the first sixth

### DIFF
--- a/src/js/layout.js
+++ b/src/js/layout.js
@@ -144,7 +144,7 @@ class Layout {
 				return;
 			}
 			window.requestAnimationFrame(() => {
-				const currentHeadingBuffer = window.innerHeight * 0.166; // 1/6th of the viewport
+				const currentHeadingBuffer = window.innerHeight * 0.333; // 1/3th of the viewport
 				const headingsScrolledPast = this.navHeadings.filter(
 					heading => heading.getBoundingClientRect().y <= currentHeadingBuffer
 				);


### PR DESCRIPTION
When a page has lots of headings which have small amounts of text beneath them, then the last few headings never end up being active because they are below the 1/6 viewport threshold we set. Changing the threshold to 1/3 viewport will enable some more of those headings to become active.

Example page which has the bug -- https://origami.ft.com/blog/2019/10/31/major-cascade/
If you scroll the page to the bottom you will see that the "Dependants" and "Release" headings are not active and one of them should be.

<img width="1280" alt="Screenshot 2019-11-01 at 11 41 30" src="https://user-images.githubusercontent.com/1569131/68022585-abdd1000-fc9c-11e9-8e5a-974c87a24791.png">
