### PR TITLE
Bump o-quote to v4

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
   ],
   "dependencies": {
     "o-typography": "^6.0.0",
-    "o-quote": "^3.0.0",
+    "o-quote": "^4.0.0",
     "o-fonts": "^4.0.0",
     "o-visual-effects": "^3.0.0",
     "o-grid": "^5.0.0",


### PR DESCRIPTION
[o-quote v3](https://github.com/Financial-Times/o-quote/releases) was accidentally released with beta dependencies.

Currently the betas from o-quote v3 are resolved:
<img width="582" alt="Screenshot 2019-11-23 at 22 37 12" src="https://user-images.githubusercontent.com/10405691/69486247-cf315000-0e41-11ea-9898-995b540fffbb.png">

o-quote v4 was updated with the proper major releases. I actually don't believe
this is breaking because all of o-quotes dependencies are shared with o-layout.