### PR TITLE
Restore in-page nav right border against content.

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -160,7 +160,7 @@
 			// source order after compilation because `oTypographyLink`
 			// uses `@supports`
 			a {
-				border: inherit;
+				border-bottom: inherit;
 				text-decoration: none;
 			}
 


### PR DESCRIPTION
This was removed by mistake in 61fa4b178d01662ba20cc4c0cccc6aeba0c37c9d