### PR TITLE
Give the floating items a default width

### DIFF
--- a/src/scss/_grid.scss
+++ b/src/scss/_grid.scss
@@ -100,6 +100,7 @@
 				max-width: calc(100% - #{$_o-layout-sidebar-max-width} - #{$_o-layout-gutter});
 				float: left;
 				clear: left;
+				width: 100%;
 			}
 			> aside {
 				box-sizing: border-box;

--- a/src/scss/_grid.scss
+++ b/src/scss/_grid.scss
@@ -100,6 +100,8 @@
 				max-width: calc(100% - #{$_o-layout-sidebar-max-width} - #{$_o-layout-gutter});
 				float: left;
 				clear: left;
+			}
+			> pre {
 				width: 100%;
 			}
 			> aside {


### PR DESCRIPTION
relates to this https://github.com/Financial-Times/origami/issues/73

i think this is a patch, but i've only tested it in firefox and i don't know if floats are still the carnival of ill effects they were during the `oldIE` days.