### PR TITLE
Remove most `minmax` uses to work around Chrome 80 bug.

### DIFF
--- a/src/scss/_grid-areas.scss
+++ b/src/scss/_grid-areas.scss
@@ -129,6 +129,7 @@
 	.o-layout__main {
 		grid-area: main;
 		margin-top: $_o-layout-gutter;
+		overflow: hidden; // overflowing content can break the o-layout position
 
 		> table {
 			box-sizing: border-box;

--- a/src/scss/_grid-areas.scss
+++ b/src/scss/_grid-areas.scss
@@ -129,7 +129,9 @@
 	.o-layout__main {
 		grid-area: main;
 		margin-top: $_o-layout-gutter;
-		overflow: hidden; // overflowing content can break the o-layout position
+		// overflowing content can break the o-layout position
+		// trust users to handle overflow content according to their project
+		overflow: hidden;
 
 		> table {
 			box-sizing: border-box;

--- a/src/scss/_grid.scss
+++ b/src/scss/_grid.scss
@@ -85,7 +85,7 @@
 				"header header"
 				"sidebar main"
 				"footer footer";
-			grid-template-columns: $_o-layout-sidebar minmax($_o-layout-main-min-width + $_o-layout-sidebar-max-width + $_o-layout-gutter, 1fr);
+			grid-template-columns: $_o-layout-sidebar-width  1fr;
 			grid-template-rows: auto 1fr auto;
 		};
 	}
@@ -97,7 +97,7 @@
 		@include oGridRespondTo($from: L) {
 			> * {
 				box-sizing: border-box;
-				max-width: calc(100% - #{$_o-layout-sidebar-max-width} - #{$_o-layout-gutter});
+				max-width: calc(100% - #{$_o-layout-sidebar-width } - #{$_o-layout-gutter});
 				float: left;
 				clear: left;
 			}
@@ -107,7 +107,7 @@
 			}
 			> aside {
 				box-sizing: border-box;
-				width: $_o-layout-sidebar-max-width;
+				width: $_o-layout-sidebar-width ;
 				margin-bottom: oSpacingByName('m12');
 				float: right;
 				clear: right;
@@ -153,7 +153,7 @@
 
 		@include oGridRespondTo($from: M) {
 			grid-template-rows: auto auto 1fr auto;
-			grid-template-columns: $_o-layout-sidebar $_o-layout-main;
+			grid-template-columns: $_o-layout-sidebar-width  $_o-layout-main;
 			grid-template-areas:
 				"header header"
 				"query-sidebar heading"
@@ -164,7 +164,7 @@
 
 		@include oGridRespondTo($from: L) {
 			grid-template-rows: auto auto 1fr auto;
-			grid-template-columns: $_o-layout-sidebar $_o-layout-main fit-content($_o-layout-sidebar-max-width); // fit-content makes the aside collapse with no content (optional)
+			grid-template-columns: $_o-layout-sidebar-width  $_o-layout-main fit-content($_o-layout-sidebar-width); // fit-content makes the aside collapse with no content, so the aside bar can be optional
 			grid-template-areas:
 				"header header header"
 				"query-sidebar heading aside-sidebar"
@@ -191,7 +191,7 @@
 
 		.o-layout__aside-sidebar {
 			@include oGridRespondTo($from: L) {
-				width: $_o-layout-sidebar-max-width; // So the sidebar can be deleted, the query area fits to content width.
+				width: $_o-layout-sidebar-width ; // So the sidebar can be deleted, the query area fits to content width.
 				margin: $_o-layout-gutter 0;
 				padding-left: $_o-layout-gutter;
 				border-left: 1px solid oColorsByName('slate-white-15');

--- a/src/scss/_grid.scss
+++ b/src/scss/_grid.scss
@@ -85,7 +85,7 @@
 				"header header"
 				"sidebar main"
 				"footer footer";
-			grid-template-columns: $_o-layout-sidebar-width  1fr;
+			grid-template-columns: $_o-layout-sidebar-width 1fr;
 			grid-template-rows: auto 1fr auto;
 		};
 	}
@@ -97,7 +97,7 @@
 		@include oGridRespondTo($from: L) {
 			> * {
 				box-sizing: border-box;
-				max-width: calc(100% - #{$_o-layout-sidebar-width } - #{$_o-layout-gutter});
+				max-width: calc(100% - #{$_o-layout-sidebar-width} - #{$_o-layout-gutter});
 				float: left;
 				clear: left;
 			}
@@ -107,7 +107,7 @@
 			}
 			> aside {
 				box-sizing: border-box;
-				width: $_o-layout-sidebar-width ;
+				width: $_o-layout-sidebar-width;
 				margin-bottom: oSpacingByName('m12');
 				float: right;
 				clear: right;
@@ -153,7 +153,7 @@
 
 		@include oGridRespondTo($from: M) {
 			grid-template-rows: auto auto 1fr auto;
-			grid-template-columns: $_o-layout-sidebar-width  $_o-layout-main;
+			grid-template-columns: $_o-layout-sidebar-width $_o-layout-main;
 			grid-template-areas:
 				"header header"
 				"query-sidebar heading"
@@ -164,7 +164,7 @@
 
 		@include oGridRespondTo($from: L) {
 			grid-template-rows: auto auto 1fr auto;
-			grid-template-columns: $_o-layout-sidebar-width  $_o-layout-main fit-content($_o-layout-sidebar-width); // fit-content makes the aside collapse with no content, so the aside bar can be optional
+			grid-template-columns: $_o-layout-sidebar-width $_o-layout-main fit-content($_o-layout-sidebar-width); // fit-content makes the aside collapse with no content, so the aside bar can be optional
 			grid-template-areas:
 				"header header header"
 				"query-sidebar heading aside-sidebar"
@@ -191,7 +191,7 @@
 
 		.o-layout__aside-sidebar {
 			@include oGridRespondTo($from: L) {
-				width: $_o-layout-sidebar-width ; // So the sidebar can be deleted, the query area fits to content width.
+				width: $_o-layout-sidebar-width; // So the sidebar can be deleted, the query area fits to content width.
 				margin: $_o-layout-gutter 0;
 				padding-left: $_o-layout-gutter;
 				border-left: 1px solid oColorsByName('slate-white-15');

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -12,5 +12,5 @@ $o-layout-is-silent: true !default;
 /// Base layout measurements
 $_o-layout-gutter: 1rem;
 $_o-layout-container-max-width: oGridGetMaxWidthForLayout($o-grid-fixed-layout); // To align with o-header-services.
-$_o-layout-sidebar-width : 16.5rem;
+$_o-layout-sidebar-width: 16.5rem;
 $_o-layout-main: 1fr;

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -12,7 +12,5 @@ $o-layout-is-silent: true !default;
 /// Base layout measurements
 $_o-layout-gutter: 1rem;
 $_o-layout-container-max-width: oGridGetMaxWidthForLayout($o-grid-fixed-layout); // To align with o-header-services.
-$_o-layout-sidebar-max-width: 16.5rem;
-$_o-layout-sidebar: minmax(auto, $_o-layout-sidebar-max-width);
-$_o-layout-main-min-width: 15rem;
-$_o-layout-main: minmax($_o-layout-main-min-width, 1fr);
+$_o-layout-sidebar-width : 16.5rem;
+$_o-layout-main: 1fr;


### PR DESCRIPTION
Chrome 80 appears to have introduced a Grid bug which impacts
o-layout:
https://bugs.chromium.org/p/chromium/issues/detail?id=1050307&q=grid&can=2

https://financialtimes.slack.com/archives/C02FU5ARJ/p1581329216120900
![image (1)](https://user-images.githubusercontent.com/10405691/74175119-1226e680-4c2d-11ea-9e03-b27fd7f486ca.png)

This PR attempts to work around that bug by removing most uses
of `minmax`. These changes impact the documentation and query
layout.

It appears we can remove these `minmax` uses safely because:
- The sidebars should not change in width according to content. When
a user navigates around the page the main content area should be in
the same position.
- Given the sidebars have a set width, the main content area does
not need a min size -- it can take the remaining space with 1fr.

If content overflows the main grid area `minmax(32.5rem,1fr)` would
allow the content to overflow without increasing the grid. With
a main area of `1fr` it appears the grid increases in width with
overflow content and visibly breaks the layout more dramatically.
Instead don't allow overflow on the main area and trust users
to address overflow as they see fit for their project.
