### PR TITLE
Rewrite layout grids to avoid header full-width  breakout.

### DIFF
--- a/src/scss/_grid.scss
+++ b/src/scss/_grid.scss
@@ -55,7 +55,6 @@
 			". main ."
 			"footer footer footer";
 		grid-template-rows: auto auto 1fr auto;
-		// 0 column width ro create a grid gap the header and footer can span
 		grid-template-columns: 1fr minmax(auto, calc(#{$_o-layout-container-max-width} - #{$column-gap-count * $_o-layout-gutter})) 1fr;
 	}
 }

--- a/src/scss/_grid.scss
+++ b/src/scss/_grid.scss
@@ -55,6 +55,8 @@
 			". main ."
 			"footer footer footer";
 		grid-template-rows: auto auto 1fr auto;
+		// make the main area have a max width equal to the o-layout container
+		// size, accounting for grid gaps
 		grid-template-columns: 1fr minmax(auto, calc(#{$_o-layout-container-max-width} - #{$column-gap-count * $_o-layout-gutter})) 1fr;
 	}
 }
@@ -77,7 +79,8 @@
 				"header header header header"
 				". sidebar main ."
 				"footer footer footer footer";
-			// grid gutter to align with o-header-services
+			// make the main and sidebar area have a max width equal to the
+			// o-layout container size, accounting for grid gaps
 			grid-template-columns: 1fr $_o-layout-sidebar-width minmax(0, calc(#{$_o-layout-container-max-width} - #{$_o-layout-sidebar-width} - #{$column-gap-count * $_o-layout-gutter})) 1fr;
 			grid-template-rows: auto 1fr auto;
 		};
@@ -134,6 +137,8 @@
 /// Grid for query layout.
 /// @access private
 @mixin _oLayoutQueryGrid() {
+	// make the main and optional sidebar areas have a max width equal to the
+	// o-layout container size my having two extra columns for margin
 	$margin-grid-size: calc((100% - #{$_o-layout-container-max-width}) / 2);
 	.o-layout.o-layout--query {
 		grid-template-rows: auto auto auto 1fr auto auto;

--- a/src/scss/_grid.scss
+++ b/src/scss/_grid.scss
@@ -22,18 +22,6 @@
 		/* autoprefixer: on */
 		box-sizing: border-box;
 		min-height: 100vh;
-		max-width: $_o-layout-container-max-width;
-		margin: auto;
-		padding: 0 (oGridGutter() * 2); // To align with o-header-services.
-	}
-
-	.o-layout__footer,
-	.o-layout__header {
-		// Position to the left of the viewport.
-		// Relative to the center aligned grid.
-		position: relative;
-		width: 100vw;
-		left: #{calc((100vw - 100%) * -0.5)};
 	}
 }
 
@@ -60,12 +48,15 @@
 /// @access private
 @mixin _oLayoutLandingGrid() {
 	.o-layout.o-layout--landing {
+		$column-gap-count: 2;
 		grid-template-areas:
-			"header"
-			"hero"
-			"main"
-			"footer";
+			"header header header"
+			". hero ."
+			". main ."
+			"footer footer footer";
 		grid-template-rows: auto auto 1fr auto;
+		// 0 column width ro create a grid gap the header and footer can span
+		grid-template-columns: 1fr minmax(auto, calc(#{$_o-layout-container-max-width} - #{$column-gap-count * $_o-layout-gutter})) 1fr;
 	}
 }
 
@@ -74,18 +65,21 @@
 @mixin _oLayoutDocsGrid() {
 	.o-layout.o-layout--docs {
 		grid-template-rows: auto auto 1fr auto;
+		grid-template-columns: 0 1fr 0; // create a grid gap the header and footer can span
 		grid-template-areas:
-			"header"
-			"sidebar"
-			"main"
-			"footer";
+			"header header header"
+			". sidebar ."
+			". main ."
+			"footer footer footer";
 
 		@include oGridRespondTo($from: M) {
+			$column-gap-count: 3;
 			grid-template-areas:
-				"header header"
-				"sidebar main"
-				"footer footer";
-			grid-template-columns: $_o-layout-sidebar-width 1fr;
+				"header header header header"
+				". sidebar main ."
+				"footer footer footer footer";
+			// grid gutter to align with o-header-services
+			grid-template-columns: 1fr $_o-layout-sidebar-width minmax(0, calc(#{$_o-layout-container-max-width} - #{$_o-layout-sidebar-width} - #{$column-gap-count * $_o-layout-gutter})) 1fr;
 			grid-template-rows: auto 1fr auto;
 		};
 	}
@@ -141,35 +135,38 @@
 /// Grid for query layout.
 /// @access private
 @mixin _oLayoutQueryGrid() {
+	$margin-grid-size: calc((100% - #{$_o-layout-container-max-width}) / 2);
 	.o-layout.o-layout--query {
 		grid-template-rows: auto auto auto 1fr auto auto;
+		grid-template-columns: $margin-grid-size 1fr $margin-grid-size;
 		grid-template-areas:
-			"header"
-			"heading"
-			"query-sidebar"
-			"main"
-			"aside-sidebar"
-			"footer";
+			"header header header"
+			". heading ."
+			". query-sidebar ."
+			". main ."
+			". aside-sidebar ."
+			"footer footer footer";
 
 		@include oGridRespondTo($from: M) {
 			grid-template-rows: auto auto 1fr auto;
-			grid-template-columns: $_o-layout-sidebar-width $_o-layout-main;
+			grid-template-columns: $margin-grid-size $_o-layout-sidebar-width $_o-layout-main $margin-grid-size;
 			grid-template-areas:
-				"header header"
-				"query-sidebar heading"
-				"query-sidebar main"
-				"query-sidebar aside-sidebar"
-				"footer footer";
+				"header header header header"
+				". query-sidebar heading ."
+				". query-sidebar main ."
+				". query-sidebar aside-sidebar ."
+				"footer footer footer footer";
 		};
 
 		@include oGridRespondTo($from: L) {
-			grid-template-rows: auto auto 1fr auto;
-			grid-template-columns: $_o-layout-sidebar-width $_o-layout-main fit-content($_o-layout-sidebar-width); // fit-content makes the aside collapse with no content, so the aside bar can be optional
 			grid-template-areas:
-				"header header header"
-				"query-sidebar heading aside-sidebar"
-				"query-sidebar main aside-sidebar"
-				"footer footer footer";
+				"header header header header header"
+				". query-sidebar heading aside-sidebar ."
+				". query-sidebar main aside-sidebar ."
+				"footer footer footer footer footer";
+			grid-template-rows: auto auto 1fr auto;
+			// fit-content makes the aside collapse with no content, so the aside bar can be optional
+			grid-template-columns: $margin-grid-size $_o-layout-sidebar-width $_o-layout-main fit-content($_o-layout-sidebar-width) $margin-grid-size;
 		};
 
 		.o-layout__main {

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -4,7 +4,7 @@
 /// @access private
 @mixin _oLayoutRule($side: 'left') {
 	border-#{$side}: 2px solid oColorsByName('teal');
-	padding-#{$side}: $_o-layout-gutter;
+	padding-#{$side}: oSpacingByName('s3');
 }
 
 /// Base styling for the layout content

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -10,7 +10,7 @@
 $o-layout-is-silent: true !default;
 
 /// Base layout measurements
-$_o-layout-gutter: 1rem;
+$_o-layout-gutter: oGridGutter() * 2; // grid gutter to align with o-header-services
 $_o-layout-container-max-width: oGridGetMaxWidthForLayout($o-grid-fixed-layout); // To align with o-header-services.
 $_o-layout-sidebar-width: 16.5rem;
 $_o-layout-main: 1fr;


### PR DESCRIPTION
- Fixes a layout issue in Chrome 80
- Prevents horizontal scroll when scrollbars are enabled

**Prevents horizontal scroll when scrollbars are enabled. @chee pointed this issue out a while ago.**
Before/After
<img width="1472" alt="Screenshot 2020-02-11 at 16 52 21" src="https://user-images.githubusercontent.com/10405691/74260060-d190a100-4cf0-11ea-8dff-ffe86d155122.png">
<img width="1472" alt="Screenshot 2020-02-11 at 16 52 17" src="https://user-images.githubusercontent.com/10405691/74260035-c5a4df00-4cf0-11ea-9e00-0aeb5253374b.png">


**Fixes a layout issue in Chrome 80**
<img width="1455" alt="Screenshot 2020-02-11 at 16 52 56" src="https://user-images.githubusercontent.com/10405691/74260162-f6851400-4cf0-11ea-9f04-8147e853a660.png">
<img width="1455" alt="Screenshot 2020-02-11 at 16 52 56 1" src="https://user-images.githubusercontent.com/10405691/74260165-f71daa80-4cf0-11ea-9b44-0446a5666d92.png">
<img width="1061" alt="Screenshot 2020-02-11 at 16 53 05" src="https://user-images.githubusercontent.com/10405691/74260169-f7b64100-4cf0-11ea-86d4-bcc67e67db01.png">
<img width="810" alt="Screenshot 2020-02-11 at 16 53 10" src="https://user-images.githubusercontent.com/10405691/74260171-f7b64100-4cf0-11ea-9a3f-b374047895dd.png">
<img width="1470" alt="Screenshot 2020-02-11 at 16 53 20" src="https://user-images.githubusercontent.com/10405691/74260174-f84ed780-4cf0-11ea-8742-ac8b1b290eaa.png">
<img width="1021" alt="Screenshot 2020-02-11 at 16 53 23" src="https://user-images.githubusercontent.com/10405691/74260175-f84ed780-4cf0-11ea-9b60-6e107037478f.png">
<img width="640" alt="Screenshot 2020-02-11 at 16 53 27" src="https://user-images.githubusercontent.com/10405691/74260177-f8e76e00-4cf0-11ea-89c5-f3895cf05d7e.png">
<img width="1516" alt="Screenshot 2020-02-11 at 17 02 39" src="https://user-images.githubusercontent.com/10405691/74260179-f8e76e00-4cf0-11ea-98b9-d373cff97561.png">
<img width="994" alt="Screenshot 2020-02-11 at 17 02 53" src="https://user-images.githubusercontent.com/10405691/74260180-f9800480-4cf0-11ea-889f-9fd7b0486006.png">
<img width="641" alt="Screenshot 2020-02-11 at 17 03 12" src="https://user-images.githubusercontent.com/10405691/74260181-f9800480-4cf0-11ea-83f9-344ebfa160a7.png">
