### PR TITLE
Replace flexible layout columns with a `minmax` function.

### DIFF
--- a/src/scss/_grid-areas.scss
+++ b/src/scss/_grid-areas.scss
@@ -129,9 +129,6 @@
 	.o-layout__main {
 		grid-area: main;
 		margin-top: $_o-layout-gutter;
-		// overflowing content can break the o-layout position
-		// trust users to handle overflow content according to their project
-		overflow: hidden;
 
 		> table {
 			box-sizing: border-box;

--- a/src/scss/_grid.scss
+++ b/src/scss/_grid.scss
@@ -15,7 +15,7 @@
 		display: grid;
 		// make the main area have a max width equal to the o-layout container
 		// size, accounting for grid gaps
-		grid-template-columns: 1fr minmax(auto, calc(#{$_o-layout-container-max-width} - #{$column-gap-count * $_o-layout-gutter})) 1fr;
+		grid-template-columns: minmax(0, 1fr) minmax(auto, calc(#{$_o-layout-container-max-width} - #{$column-gap-count * $_o-layout-gutter})) minmax(0, 1fr);
 		grid-template-rows: auto 1fr auto;
 		grid-column-gap: $_o-layout-gutter;
 		grid-template-areas:
@@ -37,7 +37,7 @@
 			"header"
 			"main"
 			"footer";
-		grid-template-columns: 1fr;
+		grid-template-columns: minmax(0, 1fr);
 	}
 }
 
@@ -55,7 +55,7 @@
 		grid-template-rows: auto auto 1fr auto;
 		// make the main area have a max width equal to the o-layout container
 		// size, accounting for grid gaps
-		grid-template-columns: 1fr minmax(auto, calc(#{$_o-layout-container-max-width} - #{$column-gap-count * $_o-layout-gutter})) 1fr;
+		grid-template-columns: minmax(0, 1fr)  minmax(auto, calc(#{$_o-layout-container-max-width} - #{$column-gap-count * $_o-layout-gutter})) minmax(0, 1fr);
 	}
 }
 
@@ -64,7 +64,7 @@
 @mixin _oLayoutDocsGrid() {
 	.o-layout.o-layout--docs {
 		grid-template-rows: auto auto 1fr auto;
-		grid-template-columns: 0 1fr 0; // create a grid gap the header and footer can span
+		grid-template-columns: 0 minmax(0, 1fr) 0; // create a grid gap the header and footer can span
 		grid-template-areas:
 			"header header header"
 			". sidebar ."
@@ -79,7 +79,7 @@
 				"footer footer footer footer";
 			// make the main and sidebar area have a max width equal to the
 			// o-layout container size, accounting for grid gaps
-			grid-template-columns: 1fr $_o-layout-sidebar-width minmax(0, calc(#{$_o-layout-container-max-width} - #{$_o-layout-sidebar-width} - #{$column-gap-count * $_o-layout-gutter})) 1fr;
+			grid-template-columns: minmax(0, 1fr) $_o-layout-sidebar-width minmax(0, calc(#{$_o-layout-container-max-width} - #{$_o-layout-sidebar-width} - #{$column-gap-count * $_o-layout-gutter})) minmax(0, 1fr);
 			grid-template-rows: auto 1fr auto;
 		};
 	}
@@ -140,7 +140,7 @@
 	$margin-grid-size: calc((100% - #{$_o-layout-container-max-width}) / 2);
 	.o-layout.o-layout--query {
 		grid-template-rows: auto auto auto 1fr auto auto;
-		grid-template-columns: $margin-grid-size 1fr $margin-grid-size;
+		grid-template-columns: $margin-grid-size minmax(0, 1fr) $margin-grid-size;
 		grid-template-areas:
 			"header header header"
 			". heading ."
@@ -151,7 +151,7 @@
 
 		@include oGridRespondTo($from: M) {
 			grid-template-rows: auto auto 1fr auto;
-			grid-template-columns: $margin-grid-size $_o-layout-sidebar-width $_o-layout-main $margin-grid-size;
+			grid-template-columns: $margin-grid-size $_o-layout-sidebar-width minmax(0, 1fr) $margin-grid-size;
 			grid-template-areas:
 				"header header header header"
 				". query-sidebar heading ."
@@ -168,7 +168,7 @@
 				"footer footer footer footer footer";
 			grid-template-rows: auto auto 1fr auto;
 			// fit-content makes the aside collapse with no content, so the aside bar can be optional
-			grid-template-columns: $margin-grid-size $_o-layout-sidebar-width $_o-layout-main fit-content($_o-layout-sidebar-width) $margin-grid-size;
+			grid-template-columns: $margin-grid-size $_o-layout-sidebar-width minmax(0, 1fr) fit-content($_o-layout-sidebar-width) $margin-grid-size;
 		};
 
 		.o-layout__main {

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -13,4 +13,3 @@ $o-layout-is-silent: true !default;
 $_o-layout-gutter: oGridGutter() * 2; // grid gutter to align with o-header-services
 $_o-layout-container-max-width: oGridGetMaxWidthForLayout($o-grid-fixed-layout); // To align with o-header-services.
 $_o-layout-sidebar-width: 16.5rem;
-$_o-layout-main: 1fr;


### PR DESCRIPTION
`1fr` is the same as `minmax(auto, 1fr)`. It sizes the column
automatically, according the the dimentions of the column content,
and distributes one fraction of any remaining space. This means
a column becomes too large if there is some long content within it.

What we actually want is for our columns to take a fraction of
remaining space, and for any overflow to overflow `minmax(0, 1fr)`.

https://drafts.csswg.org/css-grid/#valdef-grid-template-columns-flex

Before:
<img width="1409" alt="Screenshot 2020-02-17 at 15 17 19" src="https://user-images.githubusercontent.com/10405691/74666562-a0edb300-5199-11ea-90cb-b620d0314811.png">

After:
<img width="1409" alt="Screenshot 2020-02-17 at 15 17 22" src="https://user-images.githubusercontent.com/10405691/74666567-a5b26700-5199-11ea-8c74-0a6f8f8436a5.png">
