### PR TITLE
Break long copy instead of overflowing.

### DIFF
--- a/src/scss/_grid.scss
+++ b/src/scss/_grid.scss
@@ -25,6 +25,8 @@
 		/* autoprefixer: on */
 		box-sizing: border-box;
 		min-height: 100vh;
+		// create a break if an entire word cannot be placed on its own line without overflowing
+		overflow-wrap: break-word;
 	}
 }
 


### PR DESCRIPTION
Create a break if an entire word cannot be placed on its own line
without overflowing.

before:
<img width="1409" alt="Screenshot 2020-02-17 at 15 17 22" src="https://user-images.githubusercontent.com/10405691/74667523-5a00bd00-519b-11ea-89b0-19043b8b8853.png">

after (hovering an anchor, hence the colour difference):
<img width="1409" alt="Screenshot 2020-02-17 at 15 36 14" src="https://user-images.githubusercontent.com/10405691/74667546-5ec57100-519b-11ea-9e37-c4f1cddeb5d5.png">
