### PR TITLE
Add a default margin below asides when inline with content.

### DIFF
--- a/src/scss/_grid.scss
+++ b/src/scss/_grid.scss
@@ -87,6 +87,9 @@
 	}
 
 	.o-layout.o-layout--docs > .o-layout__main {
+		> aside {
+			margin-bottom: oSpacingByName('s6');
+		}
 		@include oGridRespondTo($until: M) {
 			margin-top: 0;
 		}


### PR DESCRIPTION
Relates to https://github.com/Financial-Times/origami-website/issues/66

The main area of o-layout used to be a Grid container, so margins
within it would not collapse -- perhaps that is why this margin
isn't already there.