### PR TITLE
Stop using magic webpack imports

### DIFF
--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -57,4 +57,4 @@ const query = `
 </div>
 `;
 
-export default { docs, query, docsWithSubHeading};
+export { docs, query, docsWithSubHeading};

--- a/test/layout.test.js
+++ b/test/layout.test.js
@@ -1,11 +1,10 @@
-/* eslint-env mocha, sinon, proclaim */
+/* eslint-env mocha */
+/* global sinon, proclaim */
 
 import Layout from '../src/js/layout';
 import { docs, docsWithSubHeading, query } from './helpers/fixtures';
-import * as assert from 'proclaim';
-import sinon from 'sinon/pkg/sinon';
 
-sinon.assert.expose(assert, {
+sinon.assert.expose(proclaim, {
 	includeFail: false,
 	prefix: ''
 });
@@ -28,13 +27,13 @@ describe('Layout', () => {
 
 		it('stores `documentationLayoutElement` in a `layoutEl` property', () => {
 			const layout = new Layout(documentationLayoutElement);
-			assert.strictEqual(layout.layoutEl, documentationLayoutElement);
+			proclaim.strictEqual(layout.layoutEl, documentationLayoutElement);
 		});
 
 		it('has default options and stores them in an `options` property', () => {
 			const layout = new Layout(documentationLayoutElement);
-			assert.isObject(layout.options);
-			assert.deepEqual(layout.options, {
+			proclaim.isObject(layout.options);
+			proclaim.deepEqual(layout.options, {
 				constructNav: true,
 				navHeadingSelector: 'h1, h2, h3',
 				linkHeadings: true,
@@ -44,7 +43,7 @@ describe('Layout', () => {
 
 		it('constructs the documentation layout navigation by default', () => {
 			const layout = new Layout(documentationLayoutElement);
-			assert.strictEqual(layout.navHeadings.length, 2, `Expected to find two navigation headings but found ${layout.navHeadings.length}.`);
+			proclaim.strictEqual(layout.navHeadings.length, 2, `Expected to find two navigation headings but found ${layout.navHeadings.length}.`);
 		});
 
 		it('constructs a nested navigation when a h3 (or lower) follows a h2', (done) => {
@@ -54,7 +53,7 @@ describe('Layout', () => {
 				navHeadingSelector: 'h1, h2, h3, h4, h5, h6'
 			});
 			setTimeout(() => {
-				assert.strictEqual(
+				proclaim.strictEqual(
 					documentationLayoutElement.querySelector('.o-layout__sidebar').innerHTML.replace(/[\n\t]/g, ''),
 					'<nav class="o-layout__navigation"><ol class="o-layout__unstyled-element"><li class="o-layout__unstyled-element o-layout__navigation-title"><a class="o-layout__unstyled-element" href="#this-is-a-h1" aria-current="location">This is a heading level 1</a></li><li class="o-layout__unstyled-element "><a class="o-layout__unstyled-element" href="#this-is-a-h2" aria-current="false">This is a heading level 2</a><ol><li><a class="o-layout__unstyled-element" href="#sub-heading-1" aria-current="false">Sub heading 1</a></li><li><a class="o-layout__unstyled-element" href="#sub-heading-1b" aria-current="false">Sub heading 1b</a></li><li><a class="o-layout__unstyled-element" href="#sub-heading-2" aria-current="false">Sub heading 2</a></li></ol></li><li class="o-layout__unstyled-element "><a class="o-layout__unstyled-element" href="#this-is-a-second-h2" aria-current="false">This is a second heading level 2</a><ol><li><a class="o-layout__unstyled-element" href="#sub-heading-a" aria-current="false">Sub heading a</a></li></ol></li></ol></nav>'
 				);
@@ -64,7 +63,7 @@ describe('Layout', () => {
 
 		it('does not construct the navigation by default for the query layout', () => {
 			new Layout(queryLayoutElement);
-			assert.strictEqual(queryLayoutElement.querySelector('.o-layout__query-sidebar').innerHTML, '', 'Expected to find no navigation HTML within the query layout sidebar.');
+			proclaim.strictEqual(queryLayoutElement.querySelector('.o-layout__query-sidebar').innerHTML, '', 'Expected to find no navigation HTML within the query layout sidebar.');
 		});
 
 		it('constructs the navigation for the query layout when "constructNav" is explicit', (done) => {
@@ -72,7 +71,7 @@ describe('Layout', () => {
 				constructNav: true
 			});
 			setTimeout(() => {
-				assert.ok(queryLayoutElement.querySelector('.o-layout__query-sidebar').innerHTML, 'Expected to find navigation HTML within the query layout sidebar.');
+				proclaim.ok(queryLayoutElement.querySelector('.o-layout__query-sidebar').innerHTML, 'Expected to find navigation HTML within the query layout sidebar.');
 				done();
 			}, 100);
 		});
@@ -81,7 +80,7 @@ describe('Layout', () => {
 			new Layout(documentationLayoutElement, { navHeadingSelector: 'h1' });
 			// allow for request animation frame
 			setTimeout(() => {
-				assert.ok(document.querySelector('.o-layout__navigation'), 'Expected to find a navigation element.');
+				proclaim.ok(document.querySelector('.o-layout__navigation'), 'Expected to find a navigation element.');
 				done();
 			}, 100);
 		});
@@ -90,7 +89,7 @@ describe('Layout', () => {
 			new Layout(documentationLayoutElement, { constructNav: false });
 			// allow for request animation frame
 			setTimeout(() => {
-				assert.notOk(document.querySelector('.o-layout__navigation'), null, 'Did not expect to find a navigation element.');
+				proclaim.notOk(document.querySelector('.o-layout__navigation'), null, 'Did not expect to find a navigation element.');
 				done();
 			}, 100);
 		});
@@ -114,42 +113,42 @@ describe('Layout', () => {
 			// the second nav link in the current location in our markup,
 			// although it's not actually when the page loads
 			const navLink = document.getElementById('second-nav-link');
-			assert.equal(navLink.getAttribute('aria-current'), 'location');
+			proclaim.equal(navLink.getAttribute('aria-current'), 'location');
 			// init layout, with `constructNav: false` as we created our own
 			new Layout(documentationLayoutElement, { constructNav: false });
 			// allow for request animation frame
 			setTimeout(() => {
 				// assert the current location has been updated on init
-				assert.equal(navLink.getAttribute('aria-current'), 'false');
+				proclaim.equal(navLink.getAttribute('aria-current'), 'false');
 				done();
 			}, 100);
 		});
 
 		it('constructs linkable headings by default', () => {
 			const layout = new Layout(documentationLayoutElement);
-			assert.strictEqual(layout.linkedHeadings.length, 2, 'Expected to find two linked heading.');
+			proclaim.strictEqual(layout.linkedHeadings.length, 2, 'Expected to find two linked heading.');
 		});
 
 		it('does not construct linkable headings when "linkHeadings" is set to false', () => {
 			const layout = new Layout(documentationLayoutElement, { linkHeadings: false });
-			assert.strictEqual(layout.linkedHeadings.length, 0, 'Expected to find no linked headings.');
+			proclaim.strictEqual(layout.linkedHeadings.length, 0, 'Expected to find no linked headings.');
 		});
 
 		it('constructs linkable headings with a custom selector set by the "linkedHeadingSelector" option', () => {
 			const layout = new Layout(documentationLayoutElement, { linkedHeadingSelector: 'h1' });
-			assert.strictEqual(layout.linkedHeadings.length, 1, 'Expected to find one "h1" linked heading.');
+			proclaim.strictEqual(layout.linkedHeadings.length, 1, 'Expected to find one "h1" linked heading.');
 		});
 
 		it('constructs the navigation independently of linked headings', () => {
 			const layout = new Layout(documentationLayoutElement, { navHeadingSelector: 'h1', linkedHeadingSelector: 'h2' });
-			assert.strictEqual(layout.linkedHeadings.length, 1, 'Expected to find only one "h2" linked heading.');
-			assert.strictEqual(layout.navHeadings.length, 1, 'Expected to find only one "h1" nav heading.');
+			proclaim.strictEqual(layout.linkedHeadings.length, 1, 'Expected to find only one "h2" linked heading.');
+			proclaim.strictEqual(layout.navHeadings.length, 1, 'Expected to find only one "h1" nav heading.');
 		});
 
 		it('extracts options from the DOM', () => {
 			const getDataAttributesSpie = sinon.stub(Layout, 'getDataAttributes');
 			new Layout(documentationLayoutElement);
-			assert.calledOnce(getDataAttributesSpie);
+			proclaim.calledOnce(getDataAttributesSpie);
 			Layout.getDataAttributes.restore();
 		});
 	});
@@ -163,8 +162,8 @@ describe('Layout', () => {
 			// allow for request animation frame
 			setTimeout(() => {
 				const navItems = document.body.querySelectorAll('a');
-				assert.strictEqual(navItems[0].hash, `#${headingOneId}`);
-				assert.strictEqual(navItems[1].hash, `#${headingTwoId}`);
+				proclaim.strictEqual(navItems[0].hash, `#${headingOneId}`);
+				proclaim.strictEqual(navItems[1].hash, `#${headingTwoId}`);
 				done();
 			}, 100);
 		});
@@ -186,37 +185,37 @@ describe('Layout', () => {
 		});
 
 		it('returns an object', () => {
-			assert.isObject(returnValue);
+			proclaim.isObject(returnValue);
 		});
 
 		it('extracts values from data attributes and returns them as object keys', () => {
-			assert.strictEqual(returnValue.key, 'value');
+			proclaim.strictEqual(returnValue.key, 'value');
 		});
 
 		it('converts the keys to camel-case', () => {
-			assert.isUndefined(returnValue['another-key']);
-			assert.strictEqual(returnValue.anotherKey, 'value');
+			proclaim.isUndefined(returnValue['another-key']);
+			proclaim.strictEqual(returnValue.anotherKey, 'value');
 		});
 
 		it('ignores the `data-o-component` attribute', () => {
-			assert.isUndefined(returnValue.oComponent);
+			proclaim.isUndefined(returnValue.oComponent);
 		});
 
 		it('strips "o-layout" from the key', () => {
-			assert.isUndefined(returnValue.oLayoutFoo);
-			assert.strictEqual(returnValue.foo, 'bar');
+			proclaim.isUndefined(returnValue.oLayoutFoo);
+			proclaim.strictEqual(returnValue.foo, 'bar');
 		});
 
 		it('parses the key as JSON if it\'s valid', () => {
-			assert.isObject(returnValue.json);
-			assert.deepEqual(returnValue.json, {
+			proclaim.isObject(returnValue.json);
+			proclaim.deepEqual(returnValue.json, {
 				foo: 'bar'
 			});
 		});
 
 		it('parses the key as JSON even if single quotes are used', () => {
-			assert.isObject(returnValue.jsonSingle);
-			assert.deepEqual(returnValue.jsonSingle, {
+			proclaim.isObject(returnValue.jsonSingle);
+			proclaim.deepEqual(returnValue.jsonSingle, {
 				foo: 'bar'
 			});
 		});

--- a/test/linked-heading.test.js
+++ b/test/linked-heading.test.js
@@ -1,10 +1,9 @@
 /* eslint-env mocha */
+/* global proclaim sinon */
 
 import LinkedHeading from '../src/js/linked-heading';
-import * as assert from 'proclaim';
-import sinon from 'sinon/pkg/sinon';
 
-sinon.assert.expose(assert, {
+sinon.assert.expose(proclaim, {
 	includeFail: false,
 	prefix: ''
 });
@@ -39,24 +38,24 @@ describe('LinkedHeading', () => {
 		});
 
 		it('has a `headingElement` property set to the passed in element', () => {
-			assert.strictEqual(instance.headingElement, headingElement);
+			proclaim.strictEqual(instance.headingElement, headingElement);
 		});
 
 		it('has an `id` property set to the heading element ID', () => {
-			assert.strictEqual(instance.id, 'mock-id');
+			proclaim.strictEqual(instance.id, 'mock-id');
 		});
 
 		it('has an `options` property set to the default options', () => {
-			assert.deepEqual(instance.options, {
+			proclaim.deepEqual(instance.options, {
 				content: '#',
 				title: 'Link directly to this section of the page'
 			});
 		});
 
 		it('has a `linkElement` property set to a constructed link element', () => {
-			assert.calledOnce(LinkedHeading.prototype.constructLinkElement);
-			assert.calledWithExactly(LinkedHeading.prototype.constructLinkElement);
-			assert.strictEqual(instance.linkElement, 'mock-link-element');
+			proclaim.calledOnce(LinkedHeading.prototype.constructLinkElement);
+			proclaim.calledWithExactly(LinkedHeading.prototype.constructLinkElement);
+			proclaim.strictEqual(instance.linkElement, 'mock-link-element');
 		});
 
 		describe('.constructLinkElement()', () => {
@@ -81,7 +80,7 @@ describe('LinkedHeading', () => {
 				// allow for request animation frame
 				setTimeout(() => {
 					const actualHtml = headingElement.outerHTML.replace(/\s+/g, '');
-					assert.strictEqual(actualHtml, expectedHtml);
+					proclaim.strictEqual(actualHtml, expectedHtml);
 					done();
 				}, 100);
 			});
@@ -89,7 +88,7 @@ describe('LinkedHeading', () => {
 			it('returns the created link element', (done) => {
 				// allow for request animation frame
 				setTimeout(() => {
-					assert.strictEqual(returnValue, headingElement.querySelector('a'));
+					proclaim.strictEqual(returnValue, headingElement.querySelector('a'));
 					done();
 				}, 100);
 			});
@@ -102,7 +101,7 @@ describe('LinkedHeading', () => {
 				});
 
 				it('returns `null`', () => {
-					assert.isNull(returnValue);
+					proclaim.isNull(returnValue);
 				});
 
 			});
@@ -119,11 +118,11 @@ describe('LinkedHeading', () => {
 				});
 
 				it('returns the existing link element', () => {
-					assert.strictEqual(returnValue, existingLinkElement);
+					proclaim.strictEqual(returnValue, existingLinkElement);
 				});
 
 				it('does nothing to the DOM', () => {
-					assert.strictEqual(headingElement.innerHTML, expectedHtml);
+					proclaim.strictEqual(headingElement.innerHTML, expectedHtml);
 				});
 
 			});
@@ -153,8 +152,8 @@ describe('LinkedHeading', () => {
 		});
 
 		it('has an `options` property set to the given options', () => {
-			assert.deepEqual(instance.options, options);
-			assert.notStrictEqual(instance.options, options);
+			proclaim.deepEqual(instance.options, options);
+			proclaim.notStrictEqual(instance.options, options);
 		});
 
 	});


### PR DESCRIPTION
Stop using the magic imports for proclaim and sinon and pull them from the global because that's where Karma has added them. This is required for obt v10 to be released.