### PR TITLE
Rename `.sticky-sidebar-container` to be spec compliant.

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,14 +451,14 @@ The query sidebar supports a [generated navigation like the documentation layout
 </div>
 ```
 
-Alternatively the `.sticky-sidebar-container` class may be used as a child of the query sidebars. Its contents will stick to the top of the viewport as the user scrolls.
+Alternatively the `.o-layout-sticky-sidebar-container` class may be used as a child of the query sidebars. Its contents will stick to the top of the viewport as the user scrolls.
 
 ```html
 <div class="o-layout o-layout--query" data-o-component="o-layout">
 	<!-- ... -->
 	<div class="o-layout__aside-sidebar o-layout-typography">
 		<!-- Sticky container for sidebar content (optional) -->
-		<div class="sticky-sidebar-container">
+		<div class="o-layout-sticky-sidebar-container">
 			<!-- Your asides / additional information (optional). -->
 		</div>
 	</div>

--- a/demos/src/query-layout.mustache
+++ b/demos/src/query-layout.mustache
@@ -116,7 +116,7 @@
 
     <div class="o-layout__aside-sidebar o-layout-typography" data-o-component="o-syntax-highlight">
 		<!-- optional sticky container to hold sidebar content -->
-		<div class="sticky-sidebar-container">
+		<div class="o-layout-sticky-sidebar-container">
 			<p>Aside Sidebar: Lorem ipsum, dolor sit amet consectetur adipisicing <code class='o-syntax-highlight--html'>o-layout</code> elit. Pariatur beatae, tempora deleniti inventore impedit minus corrupti omnis esse assumenda perspiciatis?</p>
 		</div>
     </div>

--- a/main.scss
+++ b/main.scss
@@ -91,7 +91,11 @@
 	}
 
 	@if($sticky-sidebar-container) {
-		.sticky-sidebar-container {
+		// @breaking - Remove `.sticky-sidebar-container` class
+		// as it is not specification compliant, class names
+		// must be prefixed with the component name.
+		.sticky-sidebar-container,
+		.o-layout-sticky-sidebar-container {
 			position: sticky;
 			top: oSpacingByName('s3');
 		}


### PR DESCRIPTION
Component CSS classes must be prefixed with the component name.

Can't wait for a spec linting too @chee! 