### PR TITLE
add extension to relative imports to make the code work directly in a browser

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-import oLayout from './src/js/layout';
+import oLayout from './src/js/layout.js';
 
 const constructAll = function() {
 	oLayout.init();

--- a/src/js/layout.js
+++ b/src/js/layout.js
@@ -1,5 +1,5 @@
 import { throttle } from 'o-utils';
-import LinkedHeading from './linked-heading';
+import LinkedHeading from './linked-heading.js';
 
 class Layout {
 	/**

--- a/test/layout.test.js
+++ b/test/layout.test.js
@@ -1,8 +1,8 @@
 /* eslint-env mocha */
 /* global sinon, proclaim */
 
-import Layout from '../src/js/layout';
-import { docs, docsWithSubHeading, query } from './helpers/fixtures';
+import Layout from '../src/js/layout.js';
+import { docs, docsWithSubHeading, query } from './helpers/fixtures.js';
 
 sinon.assert.expose(proclaim, {
 	includeFail: false,

--- a/test/linked-heading.test.js
+++ b/test/linked-heading.test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 
-import LinkedHeading from '../src/js/linked-heading';
+import LinkedHeading from '../src/js/linked-heading.js';
 
 sinon.assert.expose(proclaim, {
 	includeFail: false,


### PR DESCRIPTION
relative imports require the full path including the extension because browsers use the import name to make a network request and they do not implicitly add a .js file extension if one is missing