### PR TITLE
Add `listing` element for use with the landing layout.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The default layout has a single content area "Main Content"
 ```html
 <div class="o-layout" data-o-component="o-layout">
 	<div class="o-layout__header">
-	    <!-- Your header & navigation here. -->
+		<!-- Your header & navigation here. -->
 	</div>
 	<div class="o-layout__main o-layout-typography">
 		<!-- Your page content here. -->
@@ -98,7 +98,7 @@ The documentation layout is intended for text-heavy pages, such as technical doc
 ```html
 <div class="o-layout o-layout--docs" data-o-component="o-layout">
 	<div class="o-layout__header">
-	    <!-- Your header & navigation here. -->
+		<!-- Your header & navigation here. -->
 	</div>
 	<div class="o-layout__sidebar o-layout-typography">
 		<!-- Your sidebar here (optional). -->
@@ -252,7 +252,7 @@ When the landing page is a sub-page of the site, the hero area may create a visu
  </div>
 ```
 
-## Overview Sections
+### Overview Sections
 
 Within the main content area the landing layout provides an overview section. The overview section is ideal for outlining key points of the landing page.
 
@@ -269,20 +269,20 @@ Overview with 3 items:
 	<div class="o-layout__main o-layout-typography">
 		<!-- Your landing page content here. -->
 		<!-- Overview -->
-        <div class="o-layout__overview">
-            <div class="o-layout-item">
-                <h2>Great For This</h2>
-                <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
-            </div>
-            <div class="o-layout-item">
-                <h2>Good For That</h2>
-                <p>Blanditiis, dolor. Autem recusandae vero ut labore?</p>
-            </div>
-            <div class="o-layout-item">
-                <h2>And More</h2>
-                <p>Corrupti nemo voluptate aperiam explicabo vitae cupiditate atque fugiat dignissimos.</p>
-            </div>
-        </div>
+		<div class="o-layout__overview">
+			<div class="o-layout-item">
+				<h2>Great For This</h2>
+				<p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
+			</div>
+			<div class="o-layout-item">
+				<h2>Good For That</h2>
+				<p>Blanditiis, dolor. Autem recusandae vero ut labore?</p>
+			</div>
+			<div class="o-layout-item">
+				<h2>And More</h2>
+				<p>Corrupti nemo voluptate aperiam explicabo vitae cupiditate atque fugiat dignissimos.</p>
+			</div>
+		</div>
 	</div>
 ```
 
@@ -379,6 +379,40 @@ Sometimes a page may have multiple overview sections. In this case it can appear
 
 [See the registry demos](https://registry.origami.ft.com/components/o-layout#demo-landing-layout) for an example landing page.
 
+### Article List
+
+The landing layout can also be used to display a list of articles. This is useful for a blog for example, especially when combined with the muted hero element `o-layout__hero--muted`.
+
+To list articles within the hero layout remove the `o-layout-typography` class from the `o-layout__main` element. Then add a child unordered list element `ul` with class `o-layout__listing` and a number of list items, as shown in the following example:
+
+```html
+ <div class="o-layout o-layout--landing" data-o-component="o-layout">
+	<div class="o-layout__header">
+		<!-- Your header & navigation here. -->
+	</div>
+	<div class="o-layout__hero o-layout__hero--muted o-layout-typography">
+		<!-- Your hero content here.  -->
+	</div>
+ 	 <div class="o-layout__main">
+		<ul class="o-layout__listing">
+			<li class="o-layout__listing__item">
+				<h2 class="o-layout__listing__item__title">
+					<a href="#">Example Article Title</a>
+				</h2>
+				<p class="o-layout__listing__item__description">Example article description / blurb.</p>
+				<p class="o-layout__listing__item__meta">
+					Posted <time datetime="2020-10-28T00:00:00Z">20 November 2020</time>
+					by Author Name. Tagged: <span>Newsletter</span>.
+				</p>
+			</li>
+		</ul>
+ 	 </div>
+	<footer class="o-layout__footer">
+		<!-- Your footer & navigation here. -->
+	</footer>
+ </div>
+```
+
 ## Query Layout
 
 The query layout is intended for search, filter, and result pages. It provides four areas (in addition to a header and a footer):
@@ -390,24 +424,24 @@ The query layout is intended for search, filter, and result pages. It provides f
 
 ```html
 <div class="o-layout o-layout--query" data-o-component="o-layout">
-    <div class="o-layout__header">
-    	<!-- Your header & navigation here. -->
-    </div>
-    <div class="o-layout__heading o-layout-typography">
-    	<!-- Your title / heading content here. -->
-    </div>
-    <div class="o-layout__query-sidebar o-layout-typography">
-    	<!-- Your search or filter inputs. -->
-    </div>
+	<div class="o-layout__header">
+		<!-- Your header & navigation here. -->
+	</div>
+	<div class="o-layout__heading o-layout-typography">
+		<!-- Your title / heading content here. -->
+	</div>
+	<div class="o-layout__query-sidebar o-layout-typography">
+		<!-- Your search or filter inputs. -->
+	</div>
 	<div class="o-layout__main o-layout-typography">
 		<!-- Your search results or other main content. -->
 	</div>
-    <div class="o-layout__aside-sidebar o-layout-typography">
-    	<!-- Your asides / additional information (optional). -->
-    </div>
-    <div class="o-layout__footer">
-    	<!-- Your footer & navigation here. -->
-    </div>
+	<div class="o-layout__aside-sidebar o-layout-typography">
+		<!-- Your asides / additional information (optional). -->
+	</div>
+	<div class="o-layout__footer">
+		<!-- Your footer & navigation here. -->
+	</div>
 </div>
 ```
 
@@ -563,7 +597,7 @@ The [documentation layout](#documentation-layout) uses JavaScript to construct a
 To generate a nav for the query layout, or turn it off for the documentation layout, explicitly set the "construct navigation" option to `true` or `false`. Either declaritively in your html with the `data-o-layout-construct-nav` attribute:
 ```html
 <div class="o-layout o-layout--query" data-o-layout-construct-nav="true" data-o-component="o-layout">
-    <!-- Layout markup. -->
+	<!-- Layout markup. -->
 </div>
 ```
 
@@ -576,7 +610,7 @@ oLayout.init(null, { constructNav: true });
 If you would like to change what items show in the generated navigation, set the "navigation heading selector" option to any valid CSS selector. Do this declaritively in your html with the `data-o-layout-nav-heading-selector` attribute:
 ```html
 <div class="o-layout o-layout--query" data-o-layout-nav-heading-selector="h1, h2, .nav-heading" data-o-component="o-layout">
-    <!-- Layout markup. -->
+	<!-- Layout markup. -->
 </div>
 ```
 

--- a/demos/src/landing-layout-listing.mustache
+++ b/demos/src/landing-layout-listing.mustache
@@ -1,0 +1,53 @@
+<div class="o-layout o-layout--landing" data-o-component="o-layout">
+    {{> shared/header}}
+
+    <div class="o-layout__hero o-layout__hero--muted o-layout-typography">
+        <h1>An Example Landing Page</h1>
+        <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
+    </div>
+
+	<div class="o-layout__main" data-o-component="o-syntax-highlight">
+        <ul class="o-layout__listing">
+            <li class="o-layout__listing__item">
+                <h2 class="o-layout__listing__item__title">
+                    <a href="#">Some Example Article</a>
+                </h2>
+
+                <p class="o-layout__listing__item__description">Lorem ipsum dolor sit amet consectetur adipisicing elit. Asperiores ipsum suscipit dolorum inventore ipsam perferendis omnis animi quo corrupti ad.</p>
+
+                <p class="o-layout__listing__item__meta">
+                    Posted <time datetime="2020-10-28T00:00:00Z">20 November 2020</time>
+                    by Author Name. Tagged: <span>Newsletter</span>.
+                </p>
+            </li>
+
+            <li class="o-layout__listing__item">
+                <h2 class="o-layout__listing__item__title">
+                    <a href="#">Lorem Ipsum Dolor Sit</a>
+                </h2>
+
+                <p class="o-layout__listing__item__description">Lorem ipsum dolor sit amet consectetur adipisicing elit. Minima culpa optio consequuntur dolorem, ab incidunt saepe quibusdam quae velit explicabo.</p>
+
+                <p class="o-layout__listing__item__meta">
+                    Posted <time datetime="2020-10-28T00:00:00Z">04 December 2019</time>
+                    by Some Other Author Name. Tagged: <span>Technology</span>.
+                </p>
+            </li>
+
+            <li class="o-layout__listing__item">
+                <h2 class="o-layout__listing__item__title">
+                    <a href="#">Aut Alias Voluptatem Quisquam</a>
+                </h2>
+
+                <p class="o-layout__listing__item__description">Lorem ipsum dolor sit amet consectetur adipisicing elit. Aut alias voluptatem quisquam laudantium voluptatum a vel saepe suscipit cum, velit aperiam reiciendis perspiciatis perferendis possimus corporis corrupti, voluptate mollitia dicta.</p>
+
+                <p class="o-layout__listing__item__meta">
+                    Posted <time datetime="2020-10-28T00:00:00Z">20 June 2019</time>
+                    by Name Namerson. Tagged: <span>Design</span>.
+                </p>
+            </li>
+        </ul>
+	</div>
+
+	{{> shared/footer}}
+</div>

--- a/main.scss
+++ b/main.scss
@@ -80,6 +80,7 @@
 		// Landing page areas.
 		@include _oLayoutAreaHero($hero-image);
 		@include _oLayoutAreaOverview();
+		@include _oLayoutAreaListing();
 	}
 
 	@if($query-layout) {

--- a/origami.json
+++ b/origami.json
@@ -24,7 +24,8 @@
 			"o-header-services@^4.0.0",
 			"o-footer-services@^3.0.0",
 			"o-buttons@^6.0.0",
-			"o-forms@^8.0.0"
+			"o-forms@^8.0.0",
+			"o-normalise@^2.0.0"
 		]
 	},
 	"demos": [

--- a/origami.json
+++ b/origami.json
@@ -45,7 +45,16 @@
 				"tagline": "Landing Layout"
 			},
 			"template": "demos/src/landing-layout.mustache",
-			"description": "Ideal for a homepage."
+			"description": "Ideal for a homepage. This demo shows the land layout's hero area paired with optional overview elements."
+		},
+		{
+			"title": "Landing Layout With Article List",
+			"name": "landing-layout-listing",
+			"data": {
+				"tagline": "Landing Layout With Article List"
+			},
+			"template": "demos/src/landing-layout-listing.mustache",
+			"description": "Ideal for a subsection or category page, the landing layout may have a muted hero area. This demo shows the muted hero area paired with an article list but any content, including the overview elements, may be used below the hero area."
 		},
 		{
 			"title": "Query Layout",

--- a/src/scss/_grid-areas.scss
+++ b/src/scss/_grid-areas.scss
@@ -146,7 +146,7 @@
 
 	.o-layout__listing__item__title {
 		@include oTypographyHeading($level: 2);
-		margin: 0 0 oSpacingByName('s2') 0 ;
+		margin: 0 0 oSpacingByName('s2') 0;
 	}
 
 	.o-layout__listing__item__description {

--- a/src/scss/_grid-areas.scss
+++ b/src/scss/_grid-areas.scss
@@ -124,6 +124,41 @@
 	}
 }
 
+/// Listing of article items
+/// @access private
+@mixin _oLayoutAreaListing() {
+	.o-layout__listing {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+	}
+
+	.o-layout__listing__item {
+		@include oTypographySans($scale: 1, $line-height: 1.4);
+		color: oColorsByUsecase('body', 'text', $fallback: null);
+		margin: 0 0 oSpacingByName('s6');
+		max-width: 60ch;
+	}
+
+	.o-layout__listing a {
+		@include oTypographyLink();
+	}
+
+	.o-layout__listing__item__title {
+		@include oTypographyHeading($level: 2);
+		margin: 0 0 8px 0 ;
+	}
+
+	.o-layout__listing__item__description {
+		margin: 0 0 4px 0;
+	}
+
+	.o-layout__listing__item__meta {
+		@include oTypographySans($scale: 0, $line-height: 1.4);
+		margin: 0;
+	}
+}
+
 /// Main Area
 /// Outputs grid main content area
 /// @access private

--- a/src/scss/_grid-areas.scss
+++ b/src/scss/_grid-areas.scss
@@ -146,11 +146,11 @@
 
 	.o-layout__listing__item__title {
 		@include oTypographyHeading($level: 2);
-		margin: 0 0 8px 0 ;
+		margin: 0 0 oSpacingByName('s2') 0 ;
 	}
 
 	.o-layout__listing__item__description {
-		margin: 0 0 4px 0;
+		margin: 0 0 oSpacingByName('s1') 0;
 	}
 
 	.o-layout__listing__item__meta {


### PR DESCRIPTION
This is useful for blogs such as origami.ft.com/blog, which
currently uses custom styles. And potentially for other FT blogs.

![Screenshot 2020-11-20 at 12 28 19](https://user-images.githubusercontent.com/10405691/99800198-e6298180-2b2b-11eb-9c50-740200d0be10.png)
