### PR TITLE
Make getDataAttributes ignore data attributes which are not in the component's namespace

### DIFF
--- a/src/js/layout.js
+++ b/src/js/layout.js
@@ -170,8 +170,8 @@ class Layout {
 		}
 		return Object.keys(layoutElement.dataset).reduce((options, key) => {
 
-			// Ignore data-o-component
-			if (key === 'oComponent') {
+			// Ignore keys which are not in the component's namespace
+			if (!key.match(/^oLayout(\w)(\w+)$/)) {
 				return options;
 			}
 


### PR DESCRIPTION
This keeps the method aligned with the definition in the component template https://github.com/Financial-Times/create-origami-component/pull/214