### PR TITLE
Allow base/landing layout main CSS grid columns to shrink to `0`.

### DIFF
--- a/demos/src/base-layout.mustache
+++ b/demos/src/base-layout.mustache
@@ -5,6 +5,8 @@
         <h1>Lorem, ipsum.</h1>
         <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Ipsum quam iure quas velit animi sunt aliquid quos esse ea, dolor eaque non repellendus commodi id inventore quae, dicta ducimus? Similique.</p>
         <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Odit, sapiente.</p>
+        <p>Long code example with overflow:</p>
+		<pre><code>https://www.example.org?example=loremipsumdolorsitametconsecteturadipisicingelitmolestiaenisidoloresiustosimiliqueveniamnesciuntliberovoluptatumvoluptatemerrorquiloremipsumdolorsitametconsecteturadipisicingelitmolestiaenisidoloresiustosimiliqueveniamnesciuntliberovoluptatumvoluptatemerrorqui</code></pre>
 	</div>
 
 	{{> shared/footer}}

--- a/src/scss/_grid.scss
+++ b/src/scss/_grid.scss
@@ -16,7 +16,7 @@
 		// make the main area have a max width equal to the o-layout container
 		// size, accounting for grid gaps
 		/*! autoprefixer: ignore next */
-		grid-template-columns: minmax(0, 1fr) minmax(auto, calc(#{$_o-layout-container-max-width} - #{$column-gap-count * $_o-layout-gutter})) minmax(0, 1fr);
+		grid-template-columns: minmax(0, 1fr) minmax(0, calc(#{$_o-layout-container-max-width} - #{$column-gap-count * $_o-layout-gutter})) minmax(0, 1fr);
 		/*! autoprefixer: ignore next */
 		grid-template-rows: auto 1fr auto;
 		/*! autoprefixer: ignore next */
@@ -60,7 +60,7 @@
 		grid-template-rows: auto auto 1fr auto;
 		// make the main area have a max width equal to the o-layout container
 		// size, accounting for grid gaps
-		grid-template-columns: minmax(0, 1fr)  minmax(auto, calc(#{$_o-layout-container-max-width} - #{$column-gap-count * $_o-layout-gutter})) minmax(0, 1fr);
+		grid-template-columns: minmax(0, 1fr)  minmax(0, calc(#{$_o-layout-container-max-width} - #{$column-gap-count * $_o-layout-gutter})) minmax(0, 1fr);
 	}
 }
 


### PR DESCRIPTION
By setting `minmax(auto, [max-container-size])` we are saying the
main column should be greater than or equal to its smallest size
which doesn’t lead to overflow (auto) and less than or equal to
the max container size (max). For pages which have long content,
such as a code block, this leads to the whole layout scrolling
horizontally on viewports smaller than the max container size --
although the code block could scroll, `auto` tries to accommodate
the element without causing scroll. The behaviour we actually want
is for any overflowing content to overflow, not to increase the
width of the whole layout beyond the viewport. We can do this with:
`minmax(0, [max-container-size])`

Before: a long code block on the base layout stretches out the whole layout,
including header and footer, beyond any viewport smaller than the max 
container size
![Screenshot 2021-02-16 at 15 42 30](https://user-images.githubusercontent.com/10405691/108087265-2e930580-706f-11eb-873d-adb43dc141ad.png)

After: the long code overflows
![Screenshot 2021-02-16 at 15 42 43](https://user-images.githubusercontent.com/10405691/108087363-47032000-706f-11eb-87ac-e181e84288ef.png)

fixes: https://github.com/Financial-Times/o-layout/issues/182
