### PR TITLE
Support `figure` in the `o-layout-typography` wrapper.

### DIFF
--- a/demos/src/documentation-layout.mustache
+++ b/demos/src/documentation-layout.mustache
@@ -17,6 +17,12 @@
 			<p>Lorem ipsum dolor sit, amet consectetur adipisicing elit. Aperiam, numquam.</p>
 		</aside>
 		<p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Vel amet minus quibusdam officia, consequuntur perspiciatis laudantium illum, expedita nostrum corrupti accusantium eligendi doloremque quisquam eos commodi temporibus tempora obcaecati. Inventore omnis blanditiis quia mollitia aperiam quibusdam dignissimos unde molestias ipsam.</p>
+		<figure>
+			<img alt="" src="https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?source=origami" />
+			<figcaption class="o-typography-caption">
+				An example figure with caption.
+			</figcaption>
+		</figure>
 		<h3 id="sub-section-2">Sub Section 2</h3>
 		<ul>
 			<li>List item 1</li>

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -87,6 +87,15 @@
 			}
 		}
 
+		figure img {
+			display: block;
+		}
+
+		figcaption:not(.o-layout__unstyled-element) {
+			@include oTypographyCaption();
+		}
+
+		figure,
 		table {
 			margin: 0 0 oSpacingByName('s4');
 		}


### PR DESCRIPTION
Before, a figure has margin which overflows the main area and the figcaption is not the Origami style:
![Screenshot 2021-03-16 at 12 21 13](https://user-images.githubusercontent.com/10405691/111308153-3f28a280-8652-11eb-97f8-515b18d3ded1.png)

After:
![Screenshot 2021-03-16 at 12 20 57](https://user-images.githubusercontent.com/10405691/111308244-58315380-8652-11eb-9389-456b4bc9efd3.png)
