### PR TITLE
Add master brand support for default, bleed, documentation layouts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # o-layout
 
-Page layouts and typography for internal tools and products.
+Whole page layouts including typography.
 
 ## Table of Contents
 
@@ -9,24 +9,28 @@ Page layouts and typography for internal tools and products.
 - [Default and Bleed Layout](#default-and-bleed-layout)
 - [Documentation Layout](#documentation-layout)
 - [Landing Layout](#landing-layout)
-- [Overview Sections](#overview-sections)
+	- [Overview Sections](#overview-sections)
+	- [Article List](#article-list)
 - [Query Layout](#query-layout)
 - [Sass](#sass)
 - [JavaScript](#javascript)
 	- [Custom Navigation](#custom-navigation)
+	- [Linking Headings](#linking-headings)
 - [Migration Guide](#migration-guide)
 - [Contact](#contact)
 - [Licence](#licence)
 
 ## Overview
 
-`o-layout` provides page layouts and typography as a starting point to create internal tools or products. Layouts provided include:
+`o-layout` provides page layouts and typography as a starting point for new pages. Layouts provided vary per brand and include:
 
-- An empty layout with contained content well (default).
-- An empty layout with full-width "bleed" content.
-- A documentation/blog page layout.
-- A landing/homepage layout.
-- A search/query page layout.
+layout | description | master brand | internal brand | whitelabel brand |
+--- | --- | :---: | :---: | :---:
+default | An empty layout with contained content well. | ✓ | ✓ | |
+bleed | An empty layout with full-width "bleed" content. | ✓ | ✓ | |
+documentation | A documentation/blog page layout. | ✓ | ✓ | |
+landing | A landing/homepage layout. | | ✓ | |
+query | A search/query page layout. | | ✓ | |
 
 ## Usage
 

--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,7 @@
     "o-colors": "^5.0.0",
     "o-normalise": "^2.0.0",
     "o-utils": "^1.0.5",
-    "o-spacing": "^2.0.0"
+    "o-spacing": "^2.0.0",
+    "o-brand": "^3.3.0"
   }
 }

--- a/demos/src/demo.js
+++ b/demos/src/demo.js
@@ -1,16 +1,5 @@
 import './../../main.js';
 
-//mega hack because we currently have no way of requesting brands for origami.json dependencies
-[...document.querySelectorAll('link')].forEach(link => {
-	const isBuildServiceLink =
-		link.href.includes('origami-build.ft.com') ||
-		link.href.includes('ft.com/__origami/service/build')
-	;
-	if (isBuildServiceLink && !link.href.includes('brand=')) {
-		link.href += '&brand=internal';
-	}
-});
-
 document.addEventListener('DOMContentLoaded', () => {
 	document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
 });

--- a/main.scss
+++ b/main.scss
@@ -32,10 +32,6 @@
 	$query-layout: index($layouts, 'query') and _oLayoutSupports('query');
 	$hero-image: map-get($opts, $key: 'hero-image');
 
-	@if(not ($docs-layout or $landing-layout or $query-layout)) {
-		@error 'Please specify the layouts to output within the `$opts` argument of `oLayout`. See the Sass documentation for more: https://registry.origami.ft.com/components/o-layout@2.2.4/sassdoc';
-	}
-
 	// Base styles.
 	@include _oLayoutBase();
 

--- a/main.scss
+++ b/main.scss
@@ -1,3 +1,4 @@
+@import 'o-brand/main';
 @import 'o-spacing/main';
 @import 'o-fonts/main';
 @import 'o-colors/main';
@@ -6,6 +7,7 @@
 @import 'o-visual-effects/main';
 @import 'o-quote/main';
 
+@import 'src/scss/brand';
 @import 'src/scss/variables';
 @import 'src/scss/functions';
 @import 'src/scss/mixins';
@@ -18,24 +20,16 @@
 	'features': ('sidebar-nav', 'sticky-sidebar-container', 'linked-headings', 'typography'),
 	'hero-image': '',
 )) {
-	@if(oBrandGetCurrentBrand() != 'internal') {
-		@error "o-layout doesn't support the \"#{oBrandGetCurrentBrand()}\" brand. " +
-			"If you are using o-layout for an internal tool or product set " +
-			"`$o-brand: 'internal';` at the top of your Sass file. To learn more about " +
-			"branded components see https://origami.ft.com/docs/components/branding/ " +
-			"or contact the Origami team.";
-	}
-
 	$layouts: map-get($opts, $key: 'layouts');
 	$features: map-get($opts, $key: 'features');
 	$linked-headings: index($features, 'linked-headings');
 	$typography: index($features, 'typography');
 	$nav: index($features, 'sidebar-nav');
 	$sticky-sidebar-container: index($features, 'sticky-sidebar-container');
-	$bleed-layout: index($layouts, 'bleed');
-	$docs-layout: index($layouts, 'documentation');
-	$landing-layout: index($layouts, 'landing');
-	$query-layout: index($layouts, 'query');
+	$bleed-layout: index($layouts, 'bleed') and _oLayoutSupports('bleed');
+	$docs-layout: index($layouts, 'documentation') and _oLayoutSupports('documentation');
+	$landing-layout: index($layouts, 'landing') and _oLayoutSupports('landing');
+	$query-layout: index($layouts, 'query') and _oLayoutSupports('query');
 	$hero-image: map-get($opts, $key: 'hero-image');
 
 	@if(not ($docs-layout or $landing-layout or $query-layout)) {

--- a/origami.json
+++ b/origami.json
@@ -10,6 +10,7 @@
 		"slack": "financialtimes/origami-support"
 	},
 	"brands": [
+		"master",
 		"internal"
 	],
 	"supportStatus": "active",
@@ -44,6 +45,7 @@
 			"data": {
 				"tagline": "Landing Layout"
 			},
+			"brands": ["internal"],
 			"template": "demos/src/landing-layout.mustache",
 			"description": "Ideal for a homepage. This demo shows the land layout's hero area paired with optional overview elements."
 		},
@@ -53,6 +55,7 @@
 			"data": {
 				"tagline": "Landing Layout With Article List"
 			},
+			"brands": ["internal"],
 			"template": "demos/src/landing-layout-listing.mustache",
 			"description": "Ideal for a subsection or category page, the landing layout may have a muted hero area. This demo shows the muted hero area paired with an article list but any content, including the overview elements, may be used below the hero area."
 		},
@@ -62,6 +65,7 @@
 			"data": {
 				"tagline": "Query Layout"
 			},
+			"brands": ["internal"],
 			"template": "demos/src/query-layout.mustache",
 			"description": "Ideal for a search or filter page."
 		},

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -1,0 +1,35 @@
+/// Helper for `o-brand` function.
+/// @access private
+@function _oLayoutGet($variables, $from: null) {
+	@return oBrandGet($component: 'o-layout', $variables: $variables, $from: $from);
+}
+
+/// Helper for `o-brand` function.
+/// @access private
+@function _oLayoutSupports($variant) {
+	@return oBrandSupportsVariant($component: 'o-layout', $variant: $variant);
+}
+
+@if oBrandGetCurrentBrand() == 'master' {
+	@include oBrandDefine('o-layout', 'master', (
+		'variables': (),
+		'supports-variants': (
+			'default',
+			'bleed',
+			'documentation',
+		)
+	));
+}
+
+@if oBrandGetCurrentBrand() == 'internal' {
+	@include oBrandDefine('o-layout', 'internal', (
+		'variables': (),
+		'supports-variants': (
+			'default',
+			'bleed',
+			'documentation',
+			'landing',
+			'query'
+		)
+	));
+}

--- a/src/scss/_grid.scss
+++ b/src/scss/_grid.scss
@@ -30,6 +30,7 @@
 		min-height: 100vh;
 		// create a break if an entire word cannot be placed on its own line without overflowing
 		overflow-wrap: break-word;
+		background-color: oColorsByUsecase('page', 'background');
 	}
 }
 

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -78,11 +78,9 @@
 		}
 
 		blockquote:not(.o-layout__unstyled-element) {
-			@include oQuoteBase;
 			@include oQuoteStandard;
 			margin-bottom: oSpacingByIncrement(7);
 			cite {
-				@include oQuoteBaseCite();
 				@include oQuoteStandardCite();
 			}
 		}


### PR DESCRIPTION
This will be used first for the legal pages of ft.com via a
Wordpress theme.

The documentation layout is the only layout required but the default
layout is a given, that the documentation layout builds on, and the
bleed layout is minimal. Other layouts have not been added as it
is likely we would want design input for more complex usecases.

Do not error is no layout is requested (there is a default now)

base:
![Screenshot 2021-04-09 at 16 11 04](https://user-images.githubusercontent.com/10405691/114201549-3a53c780-994e-11eb-9e9f-c80d48e5c6b5.png)

bleed:
![Screenshot 2021-04-09 at 16 11 06](https://user-images.githubusercontent.com/10405691/114201563-4049a880-994e-11eb-828c-144488836259.png)

documentation:
![Screenshot 2021-04-09 at 16 11 07](https://user-images.githubusercontent.com/10405691/114201596-48094d00-994e-11eb-9e11-8285f9c4a6c6.png)
