### PR TITLE
Fix hero image background (currently obscured)

### DIFF
--- a/src/scss/_grid.scss
+++ b/src/scss/_grid.scss
@@ -5,6 +5,10 @@
 	html,
 	body {
 		margin: 0;
+		// Apply to the body rather than o-layout to avoid
+		// obscuring the hero element, which makes use of a
+		// negative z-index at the time of writing.
+		background-color: oColorsByUsecase('page', 'background');
 	}
 
 	.o-layout {
@@ -30,7 +34,6 @@
 		min-height: 100vh;
 		// create a break if an entire word cannot be placed on its own line without overflowing
 		overflow-wrap: break-word;
-		background-color: oColorsByUsecase('page', 'background');
 	}
 }
 


### PR DESCRIPTION
Apply background colour to the body rather than `o-layout` to avoid
obscuring the hero element, which makes use of a negative z-index
at the time of writing.

Technically... this breaks with the spec, as does o-normalise, by
applying styles outside its owned dom. This feels reasonable for
a component which should help style whole page layouts but, in
the future, we may way to update o-layout to have a class on the
body element.

This should have been caught by out visual regression tests,
powered by Percy, but for some reason Percy marked the
relevant demo as unchanged. As shown by the below gif:
![Kapture 2021-04-12 at 16 56 20](https://user-images.githubusercontent.com/10405691/114425950-789cf100-9bb1-11eb-9833-b1e82ea2e1e3.gif)
