### PR TITLE
Use overflow-y:auto to avoid an empty scrollbar

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -110,7 +110,7 @@
 			position: sticky;
 			top: $_o-layout-gutter;
 			max-height: 100vh;
-			overflow-y: scroll;
+			overflow-y: auto;
 		}
 	}
 


### PR DESCRIPTION
from Luke Blaney on Slack:

> Hi, someone has mentioned that there's a strip of white next to the navigation in the new legal pages.  I've taken a quick look and it seems to be due to o-layout adding overflow-y: scroll; and shows up when someone has a mouse plugged in (ie not a trackpad or touchscreen).  The same thing also happens in the o-layout demo.  I was wondering if this is a deliberate design decision, or something you'd consider removing? (eg setting the overflow to auto instead)