### PR TITLE
feat: improve performance and logic around how to highlight headings in the sidebar

### DIFF
--- a/origami.json
+++ b/origami.json
@@ -6,6 +6,15 @@
 		"email": "origami.support@ft.com",
 		"slack": "financialtimes/origami-support"
 	},
+	"browserFeatures": {
+		"required": [
+			"Array.from",
+			"Array.prototype.includes",
+			"IntersectionObserver",
+			"Object.assign",
+			"Object.keys"
+		]
+	},
 	"brands": [
 		"master",
 		"internal"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
 		"@financial-times/o-quote": "^5.0.1",
 		"@financial-times/o-spacing": "^3.0.0",
 		"@financial-times/o-typography": "^7.0.1",
-		"@financial-times/o-utils": "^2.0.0",
 		"@financial-times/o-visual-effects": "^4.0.0"
 	},
 	"engines": {

--- a/src/js/layout.js
+++ b/src/js/layout.js
@@ -1,4 +1,3 @@
-import { throttle } from '@financial-times/o-utils';
 import LinkedHeading from './linked-heading.js';
 
 class Layout {

--- a/src/js/layout.js
+++ b/src/js/layout.js
@@ -168,16 +168,20 @@ class Layout {
 			});
 		});
 
-		const observer = new IntersectionObserver((elements) => {
+		function getY(domRect) {
+			return Object.prototype.hasOwnProperty.call(domRect, 'y') ? domRect.y : domRect.top;
+		}
+
+		const observer = new IntersectionObserver((entries) => {
 			if (isScrollingHighlightingEnabled) {
 				let localActiveIndex = activeIndex;
 
 				// Record index of which headings are above or below the intersection target
 				const above = [];
 				const below = [];
-				elements.forEach(element => {
-					const intersectingElemIdx = this.navHeadings.findIndex(navheading => navheading === element.target);
-					const isAbove = element.boundingClientRect.y < element.rootBounds.y;
+				entries.forEach(entry => {
+					const intersectingElemIdx = this.navHeadings.findIndex(navheading => navheading === entry.target);
+					const isAbove = getY(entry.boundingClientRect) < getY(entry.rootBounds);
 					if (isAbove) {
 						above.push(intersectingElemIdx);
 					} else {

--- a/src/js/layout.js
+++ b/src/js/layout.js
@@ -140,7 +140,7 @@ class Layout {
 						sidebarAnchor.setAttribute('aria-current', 'location');
 						activeIndex = index;
 					} else {
-						sidebarAnchor.setAttribute('aria-current', '');
+						sidebarAnchor.setAttribute('aria-current', 'false');
 					}
 				}
 				setTimeout(() => {
@@ -159,7 +159,7 @@ class Layout {
 						sidebarAnchor.setAttribute('aria-current', 'location');
 						activeIndex = index;
 					} else {
-						sidebarAnchor.setAttribute('aria-current', '');
+						sidebarAnchor.setAttribute('aria-current', 'false');
 					}
 				}
 				setTimeout(() => {
@@ -205,7 +205,7 @@ class Layout {
 					if (localActiveIndex === index) {
 						anchor.setAttribute('aria-current', 'location');
 					} else {
-						anchor.setAttribute('aria-current', '');
+						anchor.setAttribute('aria-current', 'false');
 					}
 				});
 				activeIndex = localActiveIndex;
@@ -226,7 +226,7 @@ class Layout {
 						if (activeIndex === index) {
 							anchor.setAttribute('aria-current', 'location');
 						} else {
-							anchor.setAttribute('aria-current', '');
+							anchor.setAttribute('aria-current', 'false');
 						}
 					});
 				}
@@ -244,7 +244,7 @@ class Layout {
 			if (currentLocation || defaultLocaiton) {
 				anchor.setAttribute('aria-current', 'location');
 			} else {
-				anchor.setAttribute('aria-current', '');
+				anchor.setAttribute('aria-current', 'false');
 			}
 		});
 

--- a/src/js/layout.js
+++ b/src/js/layout.js
@@ -181,7 +181,7 @@ class Layout {
 				const below = [];
 				entries.forEach(entry => {
 					const intersectingElemIdx = this.navHeadings.findIndex(navheading => navheading === entry.target);
-					const isAbove = getY(entry.boundingClientRect) < getY(entry.rootBounds);
+					const isAbove = getY(entry.boundingClientRect) < (getY(entry.rootBounds || {}) || 0);
 					if (isAbove) {
 						above.push(intersectingElemIdx);
 					} else {


### PR DESCRIPTION
This changes the implementation from using a scroll event listener to using a series of intersection observers, which run off the main thread and are built to do this work in a performant manner.

I also took this time as an opportunity to improve the logic used to determine which heading to highlight.

The logic being used now is:
- Figure out what headings are above the intersection target and what ones are below it and place them in two arrays `above` and `below`.
- Figure out the scrolling direction
- If scrolling down the page, pick the last heading which is in the `above` array
- Else pick the first heading in the `below` array

When the page is scrolled to the bottom, then the last heading is highlighted, always. This is different from the previous logic which for certain document would never highlight the last heading.

Fixes #107 